### PR TITLE
fix: create TDFs larger than a single segment

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -300,14 +300,9 @@ public class TDF {
         return Hex.encodeHexString(gmacPayload);
     }
 
-    public TDFObject createTDF(InputStream inputStream,
-                          long inputSize,
+    public TDFObject createTDF(InputStream payload,
                                OutputStream outputStream,
-                               Config.TDFConfig tdfConfig, SDK.KAS kas) throws Exception {
-        if (inputSize > MAX_TDF_INPUT_SIZE) {
-            throw new DataSizeNotSupported("can't create tdf larger than 64gb");
-        }
-
+                               Config.TDFConfig tdfConfig, SDK.KAS kas) throws IOException {
         if (tdfConfig.kasInfoList.isEmpty()) {
 
             throw new KasInfoMissing("kas information is missing");
@@ -318,51 +313,41 @@ public class TDF {
         TDFObject tdfObject = new TDFObject();
         tdfObject.prepareManifest(tdfConfig);
 
-        int segmentSize = tdfConfig.defaultSegmentSize;
-        long totalSegments = inputSize / segmentSize;
-        if (inputSize % segmentSize != 0) {
-            totalSegments += 1;
-        }
-
-        // Empty payload we still want to create a payload
-        if (totalSegments == 0) {
-            totalSegments = 1;
-        }
-
-        long encryptedSegmentSize = segmentSize + kGcmIvSize + kAesBlockSize;
+        long encryptedSegmentSize = tdfConfig.defaultSegmentSize + kGcmIvSize + kAesBlockSize;
         TDFWriter tdfWriter = new TDFWriter(outputStream);
 
-        long readPos = 0;
         StringBuilder aggregateHash = new StringBuilder();
         byte[] readBuf = new byte[tdfConfig.defaultSegmentSize];
 
         tdfObject.manifest.encryptionInformation.integrityInformation.segments = new ArrayList<>();
-        while (totalSegments != 0) {
-            long readSize = segmentSize;
-            if ((inputSize - readPos) < segmentSize) {
-                readSize = inputSize - readPos;
-            }
+        long totalSize = 0;
+        boolean finished;
+        try (var payloadOutput = tdfWriter.payload()) {
+            do {
+                int nRead = 0;
+                int readThisLoop = 0;
+                while (readThisLoop < readBuf.length && (nRead = payload.read(readBuf, readThisLoop, readBuf.length - readThisLoop)) > 0) {
+                    readThisLoop += nRead;
+                }
+                finished = nRead < 0;
+                totalSize += readThisLoop;
 
-            long n = inputStream.read(readBuf, 0, (int) readSize);
-            if (n != readSize) {
-                throw new InputStreamReadFailed("Input stream read miss match");
-            }
+                if (totalSize > MAX_TDF_INPUT_SIZE) {
+                    throw new DataSizeNotSupported("can't create tdf larger than 64gb");
+                }
+                byte[] cipherData = tdfObject.aesGcm.encrypt(readBuf, 0, readThisLoop);
+                payloadOutput.write(cipherData);
 
-            byte[] cipherData = tdfObject.aesGcm.encrypt(readBuf, 0, (int) readSize);
-            tdfWriter.appendPayload(cipherData);
+                String segmentSig = calculateSignature(cipherData, tdfObject.payloadKey, tdfConfig.segmentIntegrityAlgorithm);
 
-            String segmentSig = calculateSignature(cipherData, tdfObject.payloadKey, tdfConfig.segmentIntegrityAlgorithm);
+                aggregateHash.append(segmentSig);
+                Manifest.Segment segmentInfo = new Manifest.Segment();
+                segmentInfo.hash = Base64.getEncoder().encodeToString(segmentSig.getBytes(StandardCharsets.UTF_8));
+                segmentInfo.segmentSize = readThisLoop;
+                segmentInfo.encryptedSegmentSize = cipherData.length;
 
-            aggregateHash.append(segmentSig);
-            Manifest.Segment segmentInfo = new Manifest.Segment();
-            segmentInfo.hash = Base64.getEncoder().encodeToString(segmentSig.getBytes(StandardCharsets.UTF_8));
-            segmentInfo.segmentSize = readSize;
-            segmentInfo.encryptedSegmentSize = cipherData.length;
-
-            tdfObject.manifest.encryptionInformation.integrityInformation.segments.add(segmentInfo);
-
-            totalSegments -= 1;
-            readPos += readSize;
+                tdfObject.manifest.encryptionInformation.integrityInformation.segments.add(segmentInfo);
+            } while (!finished);
         }
 
         Manifest.RootSignature rootSignature = new Manifest.RootSignature();
@@ -377,7 +362,7 @@ public class TDF {
         rootSignature.algorithm = alg;
         tdfObject.manifest.encryptionInformation.integrityInformation.rootSignature = rootSignature;
 
-        tdfObject.manifest.encryptionInformation.integrityInformation.segmentSizeDefault = segmentSize;
+        tdfObject.manifest.encryptionInformation.integrityInformation.segmentSizeDefault = tdfConfig.defaultSegmentSize;
         tdfObject.manifest.encryptionInformation.integrityInformation.encryptedSegmentSizeDefault = (int)encryptedSegmentSize;
 
         tdfObject.manifest.encryptionInformation.integrityInformation.segmentHashAlg = kGmacIntegrityAlgorithm;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -28,6 +28,17 @@ import java.util.UUID;
 
 public class TDF {
 
+    private final long maximumSize;
+
+    public TDF() {
+        this(MAX_TDF_INPUT_SIZE);
+    }
+
+    // constructor for tests so that we can set a maximum size that's tractable for tests
+    TDF(long maximumInputSize) {
+        this.maximumSize = maximumInputSize;
+    }
+
     public static Logger logger = LoggerFactory.getLogger(TDF.class);
 
     private static final long MAX_TDF_INPUT_SIZE = 68719476736L;
@@ -62,12 +73,6 @@ public class TDF {
 
     public static class KasPublicKeyMissing extends Exception {
         public KasPublicKeyMissing(String errorMessage) {
-            super(errorMessage);
-        }
-    }
-
-    public static class InputStreamReadFailed extends Exception {
-        public InputStreamReadFailed(String errorMessage) {
             super(errorMessage);
         }
     }
@@ -331,7 +336,7 @@ public class TDF {
                 finished = nRead < 0;
                 totalSize += readThisLoop;
 
-                if (totalSize > MAX_TDF_INPUT_SIZE) {
+                if (totalSize > maximumSize) {
                     throw new DataSizeNotSupported("can't create tdf larger than 64gb");
                 }
                 byte[] cipherData = tdfObject.aesGcm.encrypt(readBuf, 0, readThisLoop);

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -302,9 +302,8 @@ public class TDF {
 
     public TDFObject createTDF(InputStream payload,
                                OutputStream outputStream,
-                               Config.TDFConfig tdfConfig, SDK.KAS kas) throws IOException {
+                               Config.TDFConfig tdfConfig, SDK.KAS kas) throws Exception {
         if (tdfConfig.kasInfoList.isEmpty()) {
-
             throw new KasInfoMissing("kas information is missing");
         }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDFWriter.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDFWriter.java
@@ -14,7 +14,7 @@ public class TDFWriter {
     }
 
     public void appendManifest(String manifest) throws IOException {
-        this.archiveWriter.file(TDF_MANIFEST_FILE_NAME, manifest.getBytes(StandardCharsets.UTF_8));
+        this.archiveWriter.data(TDF_MANIFEST_FILE_NAME, manifest.getBytes(StandardCharsets.UTF_8));
     }
 
     public OutputStream payload() throws IOException {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDFWriter.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDFWriter.java
@@ -11,18 +11,19 @@ public class TDFWriter {
 
     public TDFWriter(OutputStream destination) {
         this.destination = destination;
-        this.archiveWriter = new ZipWriter();
+        this.archiveWriter = new ZipWriter(destination);
     }
 
-    public void appendManifest(String manifest) {
-        this.archiveWriter = this.archiveWriter.file(TDF_MANIFEST_FILE_NAME, manifest.getBytes(StandardCharsets.UTF_8));
+    public void appendManifest(String manifest) throws IOException {
+        this.archiveWriter.file(TDF_MANIFEST_FILE_NAME, manifest.getBytes(StandardCharsets.UTF_8));
     }
 
-    public void appendPayload(byte[] data) {
-        this.archiveWriter = this.archiveWriter.file(TDF_PAYLOAD_FILE_NAME, data);
+    public OutputStream payload() throws IOException {
+        return this.archiveWriter.stream(TDF_PAYLOAD_FILE_NAME);
+
     }
 
     public long finish() throws IOException {
-        return this.archiveWriter.build(this.destination);
+        return this.archiveWriter.finish();
     }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDFWriter.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDFWriter.java
@@ -1,16 +1,15 @@
 package io.opentdf.platform.sdk;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 public class TDFWriter {
-    private ZipWriter archiveWriter;
-    private final OutputStream destination;
     public static final String TDF_PAYLOAD_FILE_NAME = "0.payload";
     public static final String TDF_MANIFEST_FILE_NAME = "0.manifest.json";
+    private final ZipWriter archiveWriter;
 
     public TDFWriter(OutputStream destination) {
-        this.destination = destination;
         this.archiveWriter = new ZipWriter(destination);
     }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ZipWriter.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ZipWriter.java
@@ -1,6 +1,5 @@
 package io.opentdf.platform.sdk;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -15,7 +14,6 @@ public class ZipWriter {
     private static final int ZIP_VERSION = 0x2D;
     private static final int ZIP_64_MAGIC_VAL = 0xFFFFFFFF;
     private static final long ZIP_64_END_OF_CD_RECORD_SIZE = 56;
-    private static final int ZIP_64_LOCAL_EXTENDED_INFO_EXTRA_FIELD_SIZE = 24;
 
     private static final int ZIP_64_GLOBAL_EXTENDED_INFO_EXTRA_FIELD_SIZE = 28;
 
@@ -24,75 +22,96 @@ public class ZipWriter {
     private static final int BASE_YEAR = 1980;
     private static final int DEFAULT_SECOND_VALUE = 29;
     private static final int MONTH_SHIFT = 5;
-    private static class FileBytes {
-        public FileBytes(String name, byte[] data) {
-            this.name = name;
-            this.data = data;
-        }
+    private final CountingOutputStream out;
+    private final ArrayList<FileInfo> fileInfos = new ArrayList<>();
 
-        final String name;
-        final byte[] data;
+    public ZipWriter(OutputStream out) {
+        this.out = new CountingOutputStream(out);
     }
 
-    private static class InputStream {
-        public InputStream(String name, java.io.InputStream data) {
-            this.name = name;
-            this.data = data;
-        }
+    public OutputStream stream(String name) throws IOException {
+        var startPosition = out.position;
+        long fileTime, fileDate;
+        fileTime = fileDate = getTimeDateUnMSDosFormat();
 
-        final String name;
-        private final java.io.InputStream data;
+        var nameBytes = name.getBytes(StandardCharsets.UTF_8);
+        LocalFileHeader localFileHeader = new LocalFileHeader();
+        localFileHeader.lastModifiedTime = (int) fileTime;
+        localFileHeader.lastModifiedDate = (int) fileDate;
+        localFileHeader.filenameLength = (short) nameBytes.length;
+        localFileHeader.crc32 = 0;
+        localFileHeader.generalPurposeBitFlag = (1 << 3) | (1 << 11); // we are using the data descriptor and we are using UTF-8
+        localFileHeader.compressedSize = ZIP_64_MAGIC_VAL;
+        localFileHeader.uncompressedSize = ZIP_64_MAGIC_VAL;
+        localFileHeader.extraFieldLength = 0;
+
+        localFileHeader.write(out, nameBytes);
+
+        var crc = new CRC32();
+        long fileStart = out.position;
+        return new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                crc.update(b);
+                out.write(b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                crc.update(b, off, len);
+                out.write(b, off, len);
+            }
+
+            @Override
+            public void close() throws IOException {
+                super.close();
+
+                long fileSize = out.position - fileStart;
+                long crcValue = crc.getValue();
+
+                // Write Zip64 data descriptor
+                Zip64DataDescriptor dataDescriptor = new Zip64DataDescriptor();
+                dataDescriptor.crc32 = crcValue;
+                dataDescriptor.compressedSize = fileSize;
+                dataDescriptor.uncompressedSize = fileSize;
+                dataDescriptor.write(out);
+
+                var fileInfo = new FileInfo();
+                fileInfo.offset = startPosition;
+                fileInfo.flag = (short) localFileHeader.generalPurposeBitFlag;
+                fileInfo.size = fileSize;
+                fileInfo.crc = crcValue;
+                fileInfo.filename = name;
+                fileInfo.fileTime = (short) fileTime;
+                fileInfo.fileDate = (short) fileDate;
+                fileInfo.isZip64 = true;
+
+                fileInfos.add(fileInfo);
+            }
+        };
     }
 
-    private final ArrayList<FileBytes> byteFiles = new ArrayList<>();
-    private final ArrayList<InputStream> streamFiles = new ArrayList<>();
-
-    public ZipWriter file(String name, java.io.InputStream data) {
-        streamFiles.add(new InputStream(name, data));
-        return this;
-    }
-
-    public ZipWriter file(String name, byte[] content) {
-        byteFiles.add(new FileBytes(name, content));
+    public ZipWriter file(String name, byte[] content) throws IOException {
+        fileInfos.add(writeByteArray(name, content, out));
         return this;
     }
 
     /**
      * Writes the zip file to a stream and returns the number of
      * bytes written to the stream
-     * @param sink
      * @return the number of bytes written
-     * @throws IOException
+     * @throws IOException when writing to the underlying stream causes an error
      */
-    public long build(OutputStream sink) throws IOException {
-        var out = new CountingOutputStream(sink);
-        ArrayList<FileInfo> fileInfos = new ArrayList<>();
-
-        for (var byteFile : byteFiles) {
-            var fileInfo = writeByteArray(byteFile.name, byteFile.data, out);
-            fileInfos.add(fileInfo);
-        }
-
-        for (var streamFile : streamFiles) {
-            var fileInfo = writeStream(streamFile.name, streamFile.data, out);
-            fileInfos.add(fileInfo);
-        }
-
+    public long finish() throws IOException {
         final var startOfCentralDirectory = out.position;
         for (var fileInfo : fileInfos) {
             writeCentralDirectoryHeader(fileInfo, out);
         }
-
         final var sizeOfCentralDirectory = out.position - startOfCentralDirectory;
-        writeEndOfCentralDirectory(!streamFiles.isEmpty(), fileInfos.size(), startOfCentralDirectory, sizeOfCentralDirectory, out);
+        final var isZip64 = fileInfos.stream().anyMatch(f -> f.isZip64);
+        writeEndOfCentralDirectory(isZip64, fileInfos.size(), startOfCentralDirectory, sizeOfCentralDirectory, out);
 
         return out.position;
-    }
-
-    public byte[] build() throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        build(out);
-        return out.toByteArray();
     }
 
     private static void writeCentralDirectoryHeader(FileInfo fileInfo, OutputStream out) throws IOException {
@@ -123,64 +142,6 @@ public class ZipWriter {
             zip64ExtendedInfoExtraField.localFileHeaderOffset = fileInfo.offset;
             zip64ExtendedInfoExtraField.write(out);
         }
-    }
-
-    private FileInfo writeStream(String name, java.io.InputStream data, CountingOutputStream out) throws IOException {
-        var startPosition = out.position;
-        long fileTime, fileDate;
-        fileTime = fileDate = getTimeDateUnMSDosFormat();
-
-        var nameBytes = name.getBytes(StandardCharsets.UTF_8);
-        LocalFileHeader localFileHeader = new LocalFileHeader();
-        localFileHeader.lastModifiedTime = (int) fileTime;
-        localFileHeader.lastModifiedDate = (int) fileDate;
-        localFileHeader.filenameLength = (short) nameBytes.length;
-        localFileHeader.crc32 = 0;
-        localFileHeader.generalPurposeBitFlag = (1 << 3) | (1 << 11); // we are using the data descriptor and we are using UTF-8
-        localFileHeader.compressedSize = ZIP_64_MAGIC_VAL;
-        localFileHeader.uncompressedSize = ZIP_64_MAGIC_VAL;
-        localFileHeader.extraFieldLength = 0;
-
-        localFileHeader.write(out, nameBytes);
-
-        var crc = new CRC32();
-        var outputStream = new OutputStream() {
-            @Override
-            public void write(int b) throws IOException {
-                crc.update(b);
-                out.write(b);
-            }
-
-            @Override
-            public void write(byte[] b, int off, int len) throws IOException {
-                crc.update(b, off, len);
-                out.write(b, off, len);
-            }
-        };
-
-        long fileStart = out.position;
-        data.transferTo(outputStream);
-        long fileSize = out.position - fileStart;
-        long crcValue = crc.getValue();
-
-        // Write Zip64 data descriptor
-        Zip64DataDescriptor dataDescriptor = new Zip64DataDescriptor();
-        dataDescriptor.crc32 = crcValue;
-        dataDescriptor.compressedSize = fileSize;
-        dataDescriptor.uncompressedSize = fileSize;
-        dataDescriptor.write(out);
-
-        var fileInfo = new FileInfo();
-        fileInfo.offset = startPosition;
-        fileInfo.flag = (short) localFileHeader.generalPurposeBitFlag;
-        fileInfo.size = fileSize;
-        fileInfo.crc = crcValue;
-        fileInfo.filename = name;
-        fileInfo.fileTime = (short) fileTime;
-        fileInfo.fileDate = (short) fileDate;
-        fileInfo.isZip64 = true;
-
-        return fileInfo;
     }
 
     private FileInfo writeByteArray(String name, byte[] data, CountingOutputStream out) throws IOException {
@@ -389,25 +350,6 @@ public class ZipWriter {
             buffer.putInt(externalFileAttributes);
             buffer.putInt(localHeaderOffset);
             buffer.put(filename);
-
-            out.write(buffer.array());
-            assert buffer.position() == buffer.capacity();
-        }
-    }
-
-    private static class Zip64LocalExtendedInfoExtraField {
-        final short signature = 0x0001;
-        final short size = ZIP_64_LOCAL_EXTENDED_INFO_EXTRA_FIELD_SIZE;
-        long originalSize;
-        long compressedSize;
-
-        void write(OutputStream out) throws IOException {
-            var buffer = ByteBuffer.allocate(ZIP_64_LOCAL_EXTENDED_INFO_EXTRA_FIELD_SIZE);
-            buffer.order(ByteOrder.LITTLE_ENDIAN);
-            buffer.putShort(signature);
-            buffer.putShort(size);
-            buffer.putLong(originalSize);
-            buffer.putLong(compressedSize);
 
             out.write(buffer.array());
             assert buffer.position() == buffer.capacity();

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ZipWriter.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ZipWriter.java
@@ -91,9 +91,8 @@ public class ZipWriter {
         };
     }
 
-    public ZipWriter file(String name, byte[] content) throws IOException {
+    public void data(String name, byte[] content) throws IOException {
         fileInfos.add(writeByteArray(name, content, out));
-        return this;
     }
 
     /**
@@ -108,8 +107,8 @@ public class ZipWriter {
             writeCentralDirectoryHeader(fileInfo, out);
         }
         final var sizeOfCentralDirectory = out.position - startOfCentralDirectory;
-        final var isZip64 = fileInfos.stream().anyMatch(f -> f.isZip64);
-        writeEndOfCentralDirectory(isZip64, fileInfos.size(), startOfCentralDirectory, sizeOfCentralDirectory, out);
+        final var hasZip64Entry = fileInfos.stream().anyMatch(f -> f.isZip64);
+        writeEndOfCentralDirectory(hasZip64Entry, fileInfos.size(), startOfCentralDirectory, sizeOfCentralDirectory, out);
 
         return out.position;
     }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
@@ -31,7 +31,7 @@ public class TDFE2ETest {
         ByteArrayOutputStream tdfOutputStream = new ByteArrayOutputStream();
 
         TDF tdf = new TDF();
-        tdf.createTDF(plainTextInputStream, plainText.length(), tdfOutputStream, config, sdk.kas());
+        tdf.createTDF(plainTextInputStream, tdfOutputStream, config, sdk.kas());
 
         var unwrappedData = new java.io.ByteArrayOutputStream();
         tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), unwrappedData, sdk.kas());

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -79,7 +79,7 @@ public class TDFTest {
         Config.TDFConfig config = Config.newTDFConfig(
                 Config.withKasInformation(kasInfos.toArray(Config.KASInfo[]::new)),
                 // use a random segment size that makes sure that we will use multiple segments
-                Config.withSegmentSize(1 + random.nextInt(20)),
+                Config.withSegmentSize(1 + random.nextInt(20))
         );
 
         // data should be bigger than the largest segment

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -1,6 +1,5 @@
 package io.opentdf.platform.sdk;
 
-import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,7 +9,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 
@@ -66,7 +64,7 @@ public class TDFTest {
         ByteArrayOutputStream tdfOutputStream = new ByteArrayOutputStream();
 
         TDF tdf = new TDF();
-        tdf.createTDF(plainTextInputStream, plainText.length(), tdfOutputStream, config, kas);
+        tdf.createTDF(plainTextInputStream, tdfOutputStream, config, kas);
 
         var unwrappedData = new java.io.ByteArrayOutputStream();
         tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), unwrappedData, kas);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -78,10 +78,12 @@ public class TDFTest {
 
         Config.TDFConfig config = Config.newTDFConfig(
                 Config.withKasInformation(kasInfos.toArray(Config.KASInfo[]::new)),
-                Config.withSegmentSize(1 + random.nextInt(19))
+                // use a random segment size that makes sure that we will use multiple segments
+                Config.withSegmentSize(1 + random.nextInt(20)),
         );
 
-        var data = new byte[random.nextInt(2048)];
+        // data should be bigger than the largest segment
+        var data = new byte[21 + random.nextInt(2048)];
         random.nextBytes(data);
         var plainTextInputStream = new ByteArrayInputStream(data);
         var tdfOutputStream = new ByteArrayOutputStream();
@@ -93,6 +95,7 @@ public class TDFTest {
         assertThat(unwrappedData.toByteArray())
                 .withFailMessage("extracted data does not match")
                 .containsExactly(data);
+
     }
 
     @Nonnull

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -43,7 +43,7 @@ public class TDFTest {
 
     @BeforeAll
     static void createKeypairs() {
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 1 + new Random().nextInt(5); i++) {
             keypairs.add(CryptoUtils.generateRSAKeypair());
         }
     }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -73,4 +73,34 @@ public class TDFTest {
                 .isEqualTo(plainText);
 
     }
+
+    @Test
+    public void testCreatingTDFWithMultipleSegments() throws Exception {
+        var kasInfos = new ArrayList<>();
+        for (int i = 0; i < keypairs.size(); i++) {
+            var kasInfo = new Config.KASInfo();
+            kasInfo.URL = Integer.toString(i);
+            kasInfo.PublicKey = null;
+            kasInfos.add(kasInfo);
+        }
+
+        Config.TDFConfig config = Config.newTDFConfig(
+                Config.withKasInformation(kasInfos.toArray(Config.KASInfo[]::new)),
+                Config.withSegmentSize(10)
+        );
+
+        String plainText = "this is an extremely important message and we need to protect it completely";
+        InputStream plainTextInputStream = new ByteArrayInputStream(plainText.getBytes());
+        ByteArrayOutputStream tdfOutputStream = new ByteArrayOutputStream();
+
+        TDF tdf = new TDF();
+        tdf.createTDF(plainTextInputStream, tdfOutputStream, config, kas);
+
+        var unwrappedData = new java.io.ByteArrayOutputStream();
+        tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), unwrappedData, kas);
+
+        assertThat(unwrappedData.toString(StandardCharsets.UTF_8))
+                .isEqualTo(plainText);
+
+    }
 }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -99,18 +99,20 @@ public class TDFTest {
     }
 
     @Test
-    public void testCreatingTooLargeTDF() throws Exception {
+    public void testCreatingTooLargeTDF() {
         var random = new Random();
-        var maxSize = 1 + random.nextInt(1024);
+        var maxSize = random.nextInt(1024);
         var numReturned = new AtomicInteger(0);
 
         // return 1 more byte than the maximum size
         var is = new InputStream() {
             @Override
             public int read() {
-                var ans = numReturned.get() > maxSize ? -1 : 1;
+                if (numReturned.get() > maxSize) {
+                    return -1;
+                }
                 numReturned.incrementAndGet();
-                return ans;
+                return 1;
             }
 
             @Override

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFWriterTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFWriterTest.java
@@ -2,9 +2,12 @@ package io.opentdf.platform.sdk;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,7 +62,9 @@ public class TDFWriterTest {
         String payload = "Hello, world!";
         FileOutputStream fileOutStream = new FileOutputStream("sample.tdf");
         TDFWriter writer = new TDFWriter(fileOutStream);
-        writer.appendPayload(payload.getBytes());
+        try (var p = writer.payload()) {
+            new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8)).transferTo(p);
+        }
         writer.appendManifest(kManifestJsonFromTDF);
         writer.finish();
         fileOutStream.close();

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ZipReaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ZipReaderTest.java
@@ -115,7 +115,7 @@ public class ZipReaderTest {
             namesToData.put(fileName, content);
 
             if (r.nextBoolean()) {
-                writer = writer.file(fileName, content);
+                writer.data(fileName, content);
             } else {
                 try (var streamEntry = writer.stream(fileName)) {
                     new ByteArrayInputStream(content).transferTo(streamEntry);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ZipReaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ZipReaderTest.java
@@ -101,7 +101,8 @@ public class ZipReaderTest {
                     return new Object[] {name, fileContent};
                 }).collect(Collectors.toList());
 
-        ZipWriter writer = new ZipWriter();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ZipWriter writer = new ZipWriter(out);
         HashMap<String, byte[]> namesToData = new HashMap<>();
         for (var data: testData) {
             var fileName = (String)data[0];
@@ -116,12 +117,13 @@ public class ZipReaderTest {
             if (r.nextBoolean()) {
                 writer = writer.file(fileName, content);
             } else {
-                writer = writer.file(fileName, new ByteArrayInputStream(content));
+                try (var streamEntry = writer.stream(fileName)) {
+                    new ByteArrayInputStream(content).transferTo(streamEntry);
+                }
             }
         }
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        writer.build(out);
+        writer.finish();
 
         var channel = new SeekableInMemoryByteChannel(out.toByteArray());
 

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ZipWriterTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ZipWriterTest.java
@@ -4,7 +4,6 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -27,12 +26,15 @@ public class ZipWriterTest {
     @Test
     public void writesMultipleFilesToArchive() throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        new ZipWriter()
+        var writer = new ZipWriter(out)
                 .file("file1∞®ƒ両†.txt", "Hello world!".getBytes(StandardCharsets.UTF_8))
-                .file("file2.txt", "Here are some more things to look at".getBytes(StandardCharsets.UTF_8))
-                .file("the streaming one", new ByteArrayInputStream("this is a long long stream".getBytes(StandardCharsets.UTF_8)))
-                .build(out);
+                .file("file2.txt", "Here are some more things to look at".getBytes(StandardCharsets.UTF_8));
 
+        try (var entry = writer.stream("the streaming one")) {
+            new ByteArrayInputStream("this is a long long stream".getBytes(StandardCharsets.UTF_8))
+                    .transferTo(entry);
+        }
+        writer.finish();
 
         SeekableByteChannel chan = new SeekableInMemoryByteChannel(out.toByteArray());
         ZipFile z = new ZipFile.Builder().setSeekableByteChannel(chan).get();
@@ -53,10 +55,10 @@ public class ZipWriterTest {
     public void createsNonZip64Archive() throws IOException {
         // when we create things using only byte arrays we create an archive that is non zip64
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        new ZipWriter()
+        new ZipWriter(out)
                 .file("file1∞®ƒ両†.txt", "Hello world!".getBytes(StandardCharsets.UTF_8))
                 .file("file2.txt", "Here are some more things to look at".getBytes(StandardCharsets.UTF_8))
-                .build(out);
+                .finish();
 
         SeekableByteChannel chan = new SeekableInMemoryByteChannel(out.toByteArray());
         ZipFile z = new ZipFile.Builder().setSeekableByteChannel(chan).get();
@@ -74,24 +76,37 @@ public class ZipWriterTest {
     @Disabled("this takes a long time and shouldn't run on build machines")
     public void testWritingLargeFile() throws IOException {
         var random = new Random();
-        long fileSize = 4096 + random.nextInt(4096);
+        // create a file between 7 and 8 GB
+        long fileSize = 0 * (1L << 30) + (long)Math.floor(random.nextDouble() * (1L << 30));
         var testFile = File.createTempFile("big-file", "");
         testFile.deleteOnExit();
         try (var out = new FileOutputStream(testFile)) {
             var buf = new byte[2048];
-            for (long i = 0; i < fileSize * 1024 * 1024; i += buf.length) {
+            for (long i = 0; i < (fileSize / buf.length); i++) {
                 random.nextBytes(buf);
                 out.write(buf);
             }
+            buf = new byte[(int)(fileSize % 2048)];
+            random.nextBytes(buf);
+            out.write(buf);
         }
+
+        assertThat(testFile.length())
+                .withFailMessage("didn't write a file of the expected size")
+                .isEqualTo(fileSize);
 
         var zipFile = File.createTempFile("zip-file", "zip");
         zipFile.deleteOnExit();
         try (var in = new FileInputStream(testFile)) {
             try (var out = new FileOutputStream(zipFile)) {
-                new ZipWriter().file("a big one", in).build(out);
+                var writer = new ZipWriter(out);
+                try (var entry = writer.stream("a big one")) {
+                    in.transferTo(entry);
+                }
+                writer.finish();
             }
         }
+
 
         var unzippedData = File.createTempFile("big-file-unzipped", "");
         unzippedData.deleteOnExit();

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ZipWriterTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ZipWriterTest.java
@@ -3,10 +3,10 @@ package io.opentdf.platform.sdk;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -26,9 +26,9 @@ public class ZipWriterTest {
     @Test
     public void writesMultipleFilesToArchive() throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        var writer = new ZipWriter(out)
-                .file("file1∞®ƒ両†.txt", "Hello world!".getBytes(StandardCharsets.UTF_8))
-                .file("file2.txt", "Here are some more things to look at".getBytes(StandardCharsets.UTF_8));
+        var writer = new ZipWriter(out);
+        writer.data("file1∞®ƒ両†.txt", "Hello world!".getBytes(StandardCharsets.UTF_8));
+        writer.data("file2.txt", "Here are some more things to look at".getBytes(StandardCharsets.UTF_8));
 
         try (var entry = writer.stream("the streaming one")) {
             new ByteArrayInputStream("this is a long long stream".getBytes(StandardCharsets.UTF_8))
@@ -55,10 +55,10 @@ public class ZipWriterTest {
     public void createsNonZip64Archive() throws IOException {
         // when we create things using only byte arrays we create an archive that is non zip64
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        new ZipWriter(out)
-                .file("file1∞®ƒ両†.txt", "Hello world!".getBytes(StandardCharsets.UTF_8))
-                .file("file2.txt", "Here are some more things to look at".getBytes(StandardCharsets.UTF_8))
-                .finish();
+        var writer = new ZipWriter(out);
+        writer.data("file1∞®ƒ両†.txt", "Hello world!".getBytes(StandardCharsets.UTF_8));
+        writer.data("file2.txt", "Here are some more things to look at".getBytes(StandardCharsets.UTF_8));
+        writer.finish();
 
         SeekableByteChannel chan = new SeekableInMemoryByteChannel(out.toByteArray());
         ZipFile z = new ZipFile.Builder().setSeekableByteChannel(chan).get();
@@ -162,7 +162,7 @@ public class ZipWriterTest {
                 .isEqualTo(testFileCRC.getValue());
     }
 
-    @NotNull
+    @Nonnull
     private static ByteArrayOutputStream getDataStream(ZipFile z, ZipArchiveEntry entry) throws IOException {
         var entry1Data = new ByteArrayOutputStream();
         z.getInputStream(entry).transferTo(entry1Data);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ZipWriterTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ZipWriterTest.java
@@ -77,7 +77,7 @@ public class ZipWriterTest {
     public void testWritingLargeFile() throws IOException {
         var random = new Random();
         // create a file between 7 and 8 GB
-        long fileSize = 0 * (1L << 30) + (long)Math.floor(random.nextDouble() * (1L << 30));
+        long fileSize = 7 * (1L << 30) + (long)Math.floor(random.nextDouble() * (1L << 30));
         var testFile = File.createTempFile("big-file", "");
         testFile.deleteOnExit();
         try (var out = new FileOutputStream(testFile)) {


### PR DESCRIPTION
The previous API was logically incorrect and the only reason that we hadn't uncovered it was because we
only had payloads that had one segment.

Previously we'd write a manifest entry for each segment. Now we return a stream that clients can write into
for the payload. So the API changes to

```java
var writer = new ZipWriter(out);
writer.data("entry one", new byte[] { ... });
try (var out = writer.stream("entry two")) {
  var fi = new FileInputStream("...");
  fi.transferTo(out);
}
writer.finish(); // write the zip manifest
```

Also change things so that we can handle streams that don't return all of the bytes requested during
a given read. Previously we assumed that a read would always return all of the bytes that might be available
in a stream.

Address https://github.com/opentdf/java-sdk/issues/66