### PR TITLE
fix: get encrypted metadata working

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/AesGcm.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/AesGcm.java
@@ -1,16 +1,16 @@
 package io.opentdf.platform.sdk;
 
-import javax.crypto.*;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.List;
 
 public class AesGcm {
     public static final int GCM_NONCE_LENGTH = 12; // in bytes
@@ -18,6 +18,39 @@ public class AesGcm {
     private static final String CIPHER_TRANSFORM = "AES/GCM/NoPadding";
 
     private final SecretKey key;
+
+    public static class Encrypted {
+        private final byte[] iv;
+        private final byte[] ciphertext;
+
+        public byte[] getIv() {
+            return iv;
+        }
+
+        public byte[] getCiphertext() {
+            return ciphertext;
+        }
+
+        public Encrypted(byte[] iv, byte[] ciphertext) {
+            this.iv = iv;
+            this.ciphertext = ciphertext;
+        }
+
+        public Encrypted(byte[] ivAndCiphertext) {
+            this.iv = new byte[GCM_NONCE_LENGTH];
+            this.ciphertext = new byte[ivAndCiphertext.length - GCM_NONCE_LENGTH];
+
+            System.arraycopy(ivAndCiphertext, 0, iv, 0, iv.length);
+            System.arraycopy(ivAndCiphertext, GCM_NONCE_LENGTH, ciphertext, 0, ciphertext.length);
+        }
+
+        public byte[] asBytes() {
+            byte[] out = new byte[iv.length + ciphertext.length];
+            System.arraycopy(iv, 0, out, 0, iv.length);
+            System.arraycopy(ciphertext, 0, out, iv.length, ciphertext.length);
+            return out;
+        }
+    }
 
     /**
      * <p>Constructor for AesGcm.</p>
@@ -37,7 +70,7 @@ public class AesGcm {
      * @param plaintext the plaintext to encrypt
      * @return the encrypted text
      */
-    public byte[][] encrypt(byte[] plaintext) throws NoSuchPaddingException, NoSuchAlgorithmException,
+    public Encrypted encrypt(byte[] plaintext) throws NoSuchPaddingException, NoSuchAlgorithmException,
             InvalidAlgorithmParameterException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         return encrypt(plaintext, 0, plaintext.length);
     }
@@ -50,7 +83,7 @@ public class AesGcm {
      * @param len input length
      * @return the encrypted text
      */
-    public byte[][] encrypt(byte[] plaintext, int offset, int len) throws NoSuchPaddingException, NoSuchAlgorithmException,
+    public Encrypted encrypt(byte[] plaintext, int offset, int len) throws NoSuchPaddingException, NoSuchAlgorithmException,
             InvalidAlgorithmParameterException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORM);
         byte[] nonce = new byte[GCM_NONCE_LENGTH];
@@ -59,7 +92,7 @@ public class AesGcm {
         cipher.init(Cipher.ENCRYPT_MODE, key, spec);
         byte[] cipherText = cipher.doFinal(plaintext, offset, len);
 
-        return new byte[][] { nonce, cipherText };
+        return new Encrypted(nonce, cipherText);
     }
 
     /**
@@ -68,15 +101,11 @@ public class AesGcm {
      * @param cipherTextWithNonce the ciphertext with nonce to decrypt
      * @return the decrypted text
      */
-    public byte[] decrypt(byte[][] cipherTextWithNonce) throws NoSuchPaddingException, NoSuchAlgorithmException,
+    public byte[] decrypt(Encrypted cipherTextWithNonce) throws NoSuchPaddingException, NoSuchAlgorithmException,
             InvalidAlgorithmParameterException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORM);
-        GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, cipherTextWithNonce[0]);
+        GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, cipherTextWithNonce.iv);
         cipher.init(Cipher.DECRYPT_MODE, key, spec);
-        return cipher.doFinal(cipherTextWithNonce[1]);
-    }
-    public byte[] decrypt(byte[] cipherTextWithNonce) throws NoSuchPaddingException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
-        return decrypt(CryptoUtils.split(cipherTextWithNonce, GCM_NONCE_LENGTH));
+        return cipher.doFinal(cipherTextWithNonce.ciphertext);
     }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/AesGcm.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/AesGcm.java
@@ -37,6 +37,9 @@ public class AesGcm {
         }
 
         public Encrypted(byte[] ivAndCiphertext) {
+            if (ivAndCiphertext.length < GCM_NONCE_LENGTH) {
+                throw new IllegalArgumentException("too short for IV and ciphertext");
+            }
             this.iv = new byte[GCM_NONCE_LENGTH];
             this.ciphertext = new byte[ivAndCiphertext.length - GCM_NONCE_LENGTH];
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/AesGcm.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/AesGcm.java
@@ -7,8 +7,10 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
 
 public class AesGcm {
     public static final int GCM_NONCE_LENGTH = 12; // in bytes

--- a/sdk/src/main/java/io/opentdf/platform/sdk/CryptoUtils.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/CryptoUtils.java
@@ -2,17 +2,12 @@ package io.opentdf.platform.sdk;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.lang.reflect.Array;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class CryptoUtils {
     private static final int KEYPAIR_SIZE = 2048;
@@ -24,33 +19,6 @@ public class CryptoUtils {
         sha256_HMAC.init(secret_key);
 
         return sha256_HMAC.doFinal(data);
-    }
-
-    public static byte[] concat(byte[] ...arrays) {
-        var totalSize = Arrays.stream(arrays).map(Array::getLength).reduce(0, Integer::sum);
-        var concatted = new byte[totalSize];
-        var pos = 0;
-        for (var array: arrays) {
-            System.arraycopy(array, 0, concatted, pos, array.length);
-            pos += array.length;
-        }
-        return concatted;
-    }
-
-    public static byte[][] split(byte[] toSplit, int ...indexes) {
-        var prevIdx = 0;
-        var idxs = Stream.concat(Arrays.stream(indexes).boxed(), Stream.of(toSplit.length)).toArray(Integer[]::new);
-        var out = new byte[idxs.length][];
-        for (int i = 0; i < idxs.length; i++) {
-            var idx = idxs[i];
-            var arr = new byte[idx - prevIdx];
-            System.arraycopy(toSplit, prevIdx, arr, 0, arr.length);
-            out[i] = arr;
-            assert(prevIdx <= idx);
-            prevIdx = idx;
-        }
-
-        return out;
     }
 
     public static KeyPair generateRSAKeypair() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/CryptoUtils.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/CryptoUtils.java
@@ -2,12 +2,17 @@ package io.opentdf.platform.sdk;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.lang.reflect.Array;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CryptoUtils {
     private static final int KEYPAIR_SIZE = 2048;
@@ -19,6 +24,33 @@ public class CryptoUtils {
         sha256_HMAC.init(secret_key);
 
         return sha256_HMAC.doFinal(data);
+    }
+
+    public static byte[] concat(byte[] ...arrays) {
+        var totalSize = Arrays.stream(arrays).map(Array::getLength).reduce(0, Integer::sum);
+        var concatted = new byte[totalSize];
+        var pos = 0;
+        for (var array: arrays) {
+            System.arraycopy(array, 0, concatted, pos, array.length);
+            pos += array.length;
+        }
+        return concatted;
+    }
+
+    public static byte[][] split(byte[] toSplit, int ...indexes) {
+        var prevIdx = 0;
+        var idxs = Stream.concat(Arrays.stream(indexes).boxed(), Stream.of(toSplit.length)).toArray(Integer[]::new);
+        var out = new byte[idxs.length][];
+        for (int i = 0; i < idxs.length; i++) {
+            var idx = idxs[i];
+            var arr = new byte[idx - prevIdx];
+            System.arraycopy(toSplit, prevIdx, arr, 0, arr.length);
+            out[i] = arr;
+            assert(prevIdx <= idx);
+            prevIdx = idx;
+        }
+
+        return out;
     }
 
     public static KeyPair generateRSAKeypair() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDFReader.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDFReader.java
@@ -45,7 +45,7 @@ public class TDFReader {
         return out.toString(StandardCharsets.UTF_8);
     }
 
-    public int readPayloadBytes(byte[] buf) {
+    int readPayloadBytes(byte[] buf) {
         int totalRead = 0;
         int nread;
         try {

--- a/sdk/src/test/java/io/opentdf/platform/sdk/AesGcmTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/AesGcmTest.java
@@ -18,8 +18,8 @@ class AesGcmTest {
         AesGcm aesGcm = new AesGcm(key);
         byte[] plaintext = "Virtru, JavaSDK!".getBytes();
 
-        byte[][] cipherText = aesGcm.encrypt(plaintext);
-        byte[] decryptedText = aesGcm.decrypt(cipherText);
+        var encrypted = aesGcm.encrypt(plaintext);
+        byte[] decryptedText = aesGcm.decrypt(encrypted);
 
         assertArrayEquals(plaintext, decryptedText);
     }
@@ -30,10 +30,11 @@ class AesGcmTest {
         AesGcm aesGcm = new AesGcm(key);
         byte[] plaintext = "Virtru, JavaSDK!".getBytes();
 
-        byte[][] cipherText = aesGcm.encrypt(plaintext);
-        cipherText[1][0] = (byte) (cipherText[1][0] ^ 0x1); // Modify the ciphertext
+        var encrypted = aesGcm.encrypt(plaintext);
+        var bytes = encrypted.asBytes();
+        bytes[12] = (byte) (bytes[12]^1);
 
-        assertThrows(BadPaddingException.class, () -> aesGcm.decrypt(cipherText));
+        assertThrows(BadPaddingException.class, () -> aesGcm.decrypt(new AesGcm.Encrypted(bytes)));
     }
 
     @Test

--- a/sdk/src/test/java/io/opentdf/platform/sdk/AesGcmTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/AesGcmTest.java
@@ -18,7 +18,7 @@ class AesGcmTest {
         AesGcm aesGcm = new AesGcm(key);
         byte[] plaintext = "Virtru, JavaSDK!".getBytes();
 
-        byte[] cipherText = aesGcm.encrypt(plaintext);
+        byte[][] cipherText = aesGcm.encrypt(plaintext);
         byte[] decryptedText = aesGcm.decrypt(cipherText);
 
         assertArrayEquals(plaintext, decryptedText);
@@ -30,8 +30,8 @@ class AesGcmTest {
         AesGcm aesGcm = new AesGcm(key);
         byte[] plaintext = "Virtru, JavaSDK!".getBytes();
 
-        byte[] cipherText = aesGcm.encrypt(plaintext);
-        cipherText[0] = (byte) (cipherText[0] ^ 0x1); // Modify the ciphertext
+        byte[][] cipherText = aesGcm.encrypt(plaintext);
+        cipherText[1][0] = (byte) (cipherText[1][0] ^ 0x1); // Modify the ciphertext
 
         assertThrows(BadPaddingException.class, () -> aesGcm.decrypt(cipherText));
     }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
@@ -34,7 +34,8 @@ public class TDFE2ETest {
         tdf.createTDF(plainTextInputStream, plainText.length(), tdfOutputStream, config, sdk.kas());
 
         var unwrappedData = new java.io.ByteArrayOutputStream();
-        tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), sdk.kas());
+        var reader = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), sdk.kas());
+        reader.readPayload(unwrappedData);
 
         assertThat(unwrappedData.toString(StandardCharsets.UTF_8)).isEqualTo("text");
     }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
@@ -34,7 +34,7 @@ public class TDFE2ETest {
         tdf.createTDF(plainTextInputStream, plainText.length(), tdfOutputStream, config, sdk.kas());
 
         var unwrappedData = new java.io.ByteArrayOutputStream();
-        tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), unwrappedData, sdk.kas());
+        tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), sdk.kas());
 
         assertThat(unwrappedData.toString(StandardCharsets.UTF_8)).isEqualTo("text");
     }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -58,7 +58,8 @@ public class TDFTest {
         }
 
         Config.TDFConfig config = Config.newTDFConfig(
-                Config.withKasInformation(kasInfos.toArray(new Config.KASInfo[0]))
+                Config.withKasInformation(kasInfos.toArray(Config.KASInfo[]::new)),
+                Config.withMetaData("here is some metadata")
         );
 
         String plainText = "this is extremely sensitive stuff!!!";
@@ -68,11 +69,12 @@ public class TDFTest {
         TDF tdf = new TDF();
         tdf.createTDF(plainTextInputStream, plainText.length(), tdfOutputStream, config, kas);
 
-        var unwrappedData = new java.io.ByteArrayOutputStream();
-        tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), unwrappedData, kas);
+        var unwrappedData = new ByteArrayOutputStream();
+        var manifest = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), unwrappedData, kas);
 
         assertThat(unwrappedData.toString(StandardCharsets.UTF_8))
                 .isEqualTo(plainText);
+
 
     }
 }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -1,6 +1,5 @@
 package io.opentdf.platform.sdk;
 
-import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,7 +9,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 
@@ -70,11 +68,12 @@ public class TDFTest {
         tdf.createTDF(plainTextInputStream, plainText.length(), tdfOutputStream, config, kas);
 
         var unwrappedData = new ByteArrayOutputStream();
-        var manifest = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), unwrappedData, kas);
+        var reader = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), kas);
+        reader.readPayload(unwrappedData);
 
         assertThat(unwrappedData.toString(StandardCharsets.UTF_8))
                 .isEqualTo(plainText);
-
+        assertThat(reader.getMetadata()).isEqualTo("here is some metadata");
 
     }
 }


### PR DESCRIPTION
The correct transformation is:
```
encryptedMetadata = base64(string({ "iv": base64(iv), "ciphertext": base64(ciphertext) })
```

addresses https://github.com/opentdf/java-sdk/issues/67