### PR TITLE
feat(core): NanoTDF resource locator protocol bit mask

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ResourceLocator.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ResourceLocator.java
@@ -25,7 +25,10 @@ public class ResourceLocator {
     }
 
     public ResourceLocator(ByteBuffer buffer) {
-        this.protocol = NanoTDFType.Protocol.values()[buffer.get()];
+        // Get the first byte and mask it with 0xF to keep only the first four bits
+        byte protocolByte = buffer.get();
+        int protocolIndex = protocolByte & 0xF;
+        this.protocol = NanoTDFType.Protocol.values()[protocolIndex];
         this.bodyLength = buffer.get();
         this.body = new byte[this.bodyLength];
         buffer.get(this.body);


### PR DESCRIPTION
This is prep for the incoming changes related to ADR below.

Updated the constructor to mask the first byte with 0xF, ensuring only the first four bits are used for indexing the protocol. This prevents potential out-of-bounds errors when retrieving values from the NanoTDFType.Protocol enum.

Issue: https://github.com/opentdf/platform/issues/1203
Specification: https://github.com/opentdf/spec/pull/40
ADR: https://github.com/opentdf/platform/issues/900