### PR TITLE
feat(sdk): add mime type.

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
@@ -16,6 +16,7 @@ public class Config {
     public static final int TDF3_KEY_SIZE = 2048;
     public static final int DEFAULT_SEGMENT_SIZE = 2 * 1024 * 1024; // 2mb
     public static final String KAS_PUBLIC_KEY_PATH = "/kas_public_key";
+    public static final String DEFAULT_MIME_TYPE = "application/octet-stream";
 
     public enum TDFFormat {
         JSONFormat,
@@ -76,6 +77,7 @@ public class Config {
             this.attributes = new ArrayList<>();
             this.kasInfoList = new ArrayList<>();
             this.assertionList = new ArrayList<>();
+            this.mimeType = DEFAULT_MIME_TYPE;
         }
     }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
@@ -65,6 +65,7 @@ public class Config {
         public List<KASInfo> kasInfoList;
         public List<Assertion> assertionList;
         public AssertionConfig assertionConfig;
+        public String mimeType;
 
         public TDFConfig() {
             this.defaultSegmentSize = DEFAULT_SEGMENT_SIZE;
@@ -123,6 +124,10 @@ public class Config {
 
     public static Consumer<TDFConfig> withDisableEncryption() {
         return (TDFConfig config) -> config.enableEncryption = false;
+    }
+
+    public static Consumer<TDFConfig> withMimeType(String mimeType) {
+        return (TDFConfig config) -> config.mimeType = mimeType;
     }
 
     public static class NanoTDFConfig {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -60,7 +60,6 @@ public class TDF {
     private static final String kSha256Hash = "SHA256";
 
     private static final String kHmacIntegrityAlgorithm = "HS256";
-    private static final String kDefaultMimeType = "application/octet-stream";
     private static final String kTDFAsZip = "zip";
     private static final String kTDFZipReference = "reference";
     private static final String kAssertionHash = "assertionHash";
@@ -426,7 +425,7 @@ public class TDF {
 
         // Add payload info
         tdfObject.manifest.payload = new Manifest.Payload();
-        tdfObject.manifest.payload.mimeType = tdfConfig.mimeType.isEmpty() ? kDefaultMimeType : tdfConfig.mimeType;
+        tdfObject.manifest.payload.mimeType = tdfConfig.mimeType;
         tdfObject.manifest.payload.protocol = kTDFAsZip;
         tdfObject.manifest.payload.type = kTDFZipReference;
         tdfObject.manifest.payload.url = TDFWriter.TDF_PAYLOAD_FILE_NAME;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -241,6 +241,10 @@ public class TDF {
             return unencryptedMetadata;
         }
 
+        public Manifest getManifest() {
+            return manifest;
+        }
+
         private final String unencryptedMetadata;
         private final AesGcm aesGcm;
 
@@ -422,7 +426,7 @@ public class TDF {
 
         // Add payload info
         tdfObject.manifest.payload = new Manifest.Payload();
-        tdfObject.manifest.payload.mimeType = kDefaultMimeType;
+        tdfObject.manifest.payload.mimeType = tdfConfig.mimeType.isEmpty() ? kDefaultMimeType : tdfConfig.mimeType;
         tdfObject.manifest.payload.protocol = kTDFAsZip;
         tdfObject.manifest.payload.type = kTDFZipReference;
         tdfObject.manifest.payload.url = TDFWriter.TDF_PAYLOAD_FILE_NAME;

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ConfigTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ConfigTest.java
@@ -49,4 +49,11 @@ class ConfigTest {
         Config.TDFConfig config = Config.newTDFConfig(Config.withSegmentSize(1024));
         assertEquals(1024, config.defaultSegmentSize);
     }
+
+    @Test
+    void withMimeType_shouldSetMimeType() {
+        final String mimeType = "application/pdf";
+        Config.TDFConfig config = Config.newTDFConfig(Config.withMimeType(mimeType));
+        assertEquals(mimeType, config.mimeType);
+    }
 }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -279,7 +279,7 @@ public class TDFTest {
         tdf.createTDF(plainTextInputStream, tdfOutputStream, config, kas);
 
         var reader = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), new Config.AssertionConfig(), kas);
-        assertThat(reader.getManifest().payload).isEqualTo(mimeType);
+        assertThat(reader.getManifest().payload.mimeType).isEqualTo(mimeType);
     }
 
     @Nonnull

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -2,6 +2,8 @@ package io.opentdf.platform.sdk;
 
 
 import com.nimbusds.jose.jwk.RSAKey;
+
+import io.opentdf.platform.sdk.TDF.TDFObject;
 import io.opentdf.platform.sdk.nanotdf.NanoTDFType;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.junit.jupiter.api.BeforeAll;
@@ -99,6 +101,8 @@ public class TDFTest {
 
         var unwrappedData = new ByteArrayOutputStream();
         var reader = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), new Config.AssertionConfig(), kas);
+        assertThat(reader.getManifest().payload.mimeType).isEqualTo("application/octet-stream");
+
         reader.readPayload(unwrappedData);
 
         assertThat(unwrappedData.toString(StandardCharsets.UTF_8))
@@ -255,6 +259,27 @@ public class TDFTest {
         assertThat(numReturned.get())
                 .withFailMessage("test returned the wrong number of bytes")
                 .isEqualTo(maxSize + 1);
+    }
+
+    @Test
+    public void testCreateTDFWithMimeType() throws Exception {
+
+        final String mimeType = "application/pdf";
+
+        Config.TDFConfig config = Config.newTDFConfig(
+                Config.withKasInformation(getKASInfos()),
+                Config.withMimeType(mimeType)
+        );
+
+        String plainText = "this is extremely sensitive stuff!!!";
+        InputStream plainTextInputStream = new ByteArrayInputStream(plainText.getBytes());
+        ByteArrayOutputStream tdfOutputStream = new ByteArrayOutputStream();
+
+        TDF tdf = new TDF();
+        tdf.createTDF(plainTextInputStream, tdfOutputStream, config, kas);
+
+        var reader = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), new Config.AssertionConfig(), kas);
+        assertThat(reader.getManifest().payload).isEqualTo(mimeType);
     }
 
     @Nonnull


### PR DESCRIPTION
- Add withMimeType TDF Config option, which will in-turn add it to the Manifest.Payload.MimeType
- Add getManifest() function to the reader object. In-sync with Golang SDK.