### PR TITLE
fix: Issue #115 - fix for SSL Context for IDP and plaintext platform

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/SDKBuilder.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/SDKBuilder.java
@@ -224,7 +224,7 @@ public class SDKBuilder {
      */
     private ManagedChannelBuilder<?> getManagedChannelBuilder(String endpoint) {
         ManagedChannelBuilder<?> channelBuilder;
-        if (sslFactory != null) {
+        if (sslFactory != null && !usePlainText) {
             channelBuilder = Grpc.newChannelBuilder(endpoint, TlsChannelCredentials.newBuilder()
                     .trustManager(sslFactory.getTrustManager().get()).build());
         }else{


### PR DESCRIPTION
fix for #115 

Note, to repro the error run the new test _testPlatformPlainTextAndIDPWithSSL_ without the fix in SDKBuilder.