### PR TITLE
fix: add stubs to attributes service 

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/AttributesClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/AttributesClient.java
@@ -11,10 +11,8 @@ public class AttributesClient implements SDK.AttributesService {
     private final ManagedChannel channel;
 
     /***
-     * A client that communicates with KAS
-     * @param channelFactory A function that produces channels that can be used to communicate
-     * @param dpopKey
-     */
+     * A client that communicates with Attributes Service
+    */
     public AttributesClient(ManagedChannel channel) {
         this.channel = channel;
     }
@@ -25,16 +23,18 @@ public class AttributesClient implements SDK.AttributesService {
         this.channel.shutdownNow();
     }
 
-
-    // make this protected so we can test the address normalization logic
-    synchronized AttributesServiceGrpc.AttributesServiceBlockingStub getStub() {
+    @Override
+    public AttributesServiceGrpc.AttributesServiceBlockingStub getAttributesServiceBlockingStub() {
         return AttributesServiceGrpc.newBlockingStub(channel);
     }
 
+    @Override
+    public AttributesServiceGrpc.AttributesServiceStub getAttributesServiceStub() {
+        return AttributesServiceGrpc.newStub(channel);
+    }
 
     @Override
-    public GetAttributeValuesByFqnsResponse getAttributeValuesByFqn(GetAttributeValuesByFqnsRequest request) {
-        return getStub().getAttributeValuesByFqns(request);
-    } 
-
+    public AttributesServiceGrpc.AttributesServiceFutureStub getAttributesServiceFutureStub() {
+        return AttributesServiceGrpc.newFutureStub(channel);
+    }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/AttributesClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/AttributesClient.java
@@ -1,14 +1,15 @@
 package io.opentdf.platform.sdk;
 
 import io.grpc.ManagedChannel;
-import io.opentdf.platform.policy.attributes.GetAttributeValuesByFqnsRequest;
 import io.opentdf.platform.policy.attributes.AttributesServiceGrpc;
-import io.opentdf.platform.policy.attributes.GetAttributeValuesByFqnsResponse;
-
 
 public class AttributesClient implements SDK.AttributesService {
 
     private final ManagedChannel channel;
+
+    private AttributesServiceGrpc.AttributesServiceBlockingStub attributesServiceBlockingStub;
+    private AttributesServiceGrpc.AttributesServiceStub attributesServiceStub;
+    private AttributesServiceGrpc.AttributesServiceFutureStub attributesServiceFutureStub;
 
     /***
      * A client that communicates with Attributes Service
@@ -24,17 +25,26 @@ public class AttributesClient implements SDK.AttributesService {
     }
 
     @Override
-    public AttributesServiceGrpc.AttributesServiceBlockingStub getAttributesServiceBlockingStub() {
-        return AttributesServiceGrpc.newBlockingStub(channel);
+    public synchronized AttributesServiceGrpc.AttributesServiceBlockingStub getAttributesServiceBlockingStub() {
+        if (attributesServiceBlockingStub==null){
+            attributesServiceBlockingStub = AttributesServiceGrpc.newBlockingStub(channel);
+        }
+        return attributesServiceBlockingStub;
     }
 
     @Override
-    public AttributesServiceGrpc.AttributesServiceStub getAttributesServiceStub() {
-        return AttributesServiceGrpc.newStub(channel);
+    public synchronized AttributesServiceGrpc.AttributesServiceStub getAttributesServiceStub() {
+        if (attributesServiceStub==null){
+            attributesServiceStub = AttributesServiceGrpc.newStub(channel);
+        }
+        return attributesServiceStub;
     }
 
     @Override
-    public AttributesServiceGrpc.AttributesServiceFutureStub getAttributesServiceFutureStub() {
-        return AttributesServiceGrpc.newFutureStub(channel);
+    public synchronized AttributesServiceGrpc.AttributesServiceFutureStub getAttributesServiceFutureStub() {
+        if (attributesServiceFutureStub==null){
+            attributesServiceFutureStub = AttributesServiceGrpc.newFutureStub(channel);
+        }
+        return attributesServiceFutureStub;
     }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
@@ -50,7 +50,9 @@ public class SDK implements AutoCloseable {
     }
 
     public interface AttributesService extends AutoCloseable {
-        GetAttributeValuesByFqnsResponse getAttributeValuesByFqn(GetAttributeValuesByFqnsRequest request);
+        AttributesServiceGrpc.AttributesServiceBlockingStub getAttributesServiceBlockingStub();
+        AttributesServiceGrpc.AttributesServiceStub getAttributesServiceStub();
+        AttributesServiceGrpc.AttributesServiceFutureStub getAttributesServiceFutureStub();
     }
 
     // TODO: add KAS

--- a/sdk/src/test/java/io/opentdf/platform/sdk/AttributeClientTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/AttributeClientTest.java
@@ -61,7 +61,7 @@ public class AttributeClientTest {
                     .usePlaintext()
                     .build();
             try (var attr = new AttributesClient(channel)) {
-                GetAttributeValuesByFqnsResponse resp = attr.getAttributeValuesByFqn(GetAttributeValuesByFqnsRequest.newBuilder().build());
+                GetAttributeValuesByFqnsResponse resp = attr.getAttributesServiceBlockingStub().getAttributeValuesByFqns(GetAttributeValuesByFqnsRequest.newBuilder().build());
                 Set<String> fqnSet = new HashSet<>(Arrays.asList("https://virtru.com/attr/classification/value/value1"));
                 assertThat(resp.getFqnAttributeValuesMap().keySet()).isEqualTo(fqnSet);
                 assertThat(resp.getFqnAttributeValuesCount()).isEqualTo(1);


### PR DESCRIPTION
add stubs to attributes service so clients can use full service functionality

currently SDK users won't be able to access the other attribute service RPC methods through the SDK