### PR TITLE
fix: Align identifier bytes correctly in ResourceLocator

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ResourceLocator.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ResourceLocator.java
@@ -60,15 +60,15 @@ public class ResourceLocator {
             } else if (identifierLen <= 2) {
                 this.identifierType = NanoTDFType.IdentifierType.TWO_BYTES;
                 this.identifier = new byte[NanoTDFType.IdentifierType.TWO_BYTES.getLength()];
-                System.arraycopy(identifier.getBytes(), 0, this.identifier, 0, identifierLen);
+                System.arraycopy(identifier.getBytes(), 0, this.identifier, this.identifier.length - identifierLen, identifierLen);
             } else if (identifierLen <= 8) {
                 this.identifierType = NanoTDFType.IdentifierType.EIGHT_BYTES;
                 this.identifier = new byte[NanoTDFType.IdentifierType.EIGHT_BYTES.getLength()];
-                System.arraycopy(identifier.getBytes(), 0, this.identifier, 0, identifierLen);
+                System.arraycopy(identifier.getBytes(), 0, this.identifier, this.identifier.length - identifierLen, identifierLen);
             } else if (identifierLen <= 32) {
                 this.identifierType = NanoTDFType.IdentifierType.THIRTY_TWO_BYTES;
                 this.identifier = new byte[NanoTDFType.IdentifierType.THIRTY_TWO_BYTES.getLength()];
-                System.arraycopy(identifier.getBytes(), 0, this.identifier, 0, identifierLen);
+                System.arraycopy(identifier.getBytes(), 0, this.identifier, this.identifier.length - identifierLen, identifierLen);
             } else {
                 throw new IllegalArgumentException("Unsupported identifier length: " + identifierLen);
             }


### PR DESCRIPTION
Adjust the starting index of System.arraycopy to correctly align the identifier bytes within the given array length. This change ensures that shorter identifiers are aligned at the end of the array, improving data consistency and correctness.

Pad right