### PR TITLE
feat(cli): Add insecure option for https connections

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -138,21 +138,21 @@ jobs:
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -p \
             encrypt --kas-url=localhost:8080 --mime-type=text/plain --attr https://example.com/attr/attr1/value/value1 --autoconfigure=false -f data -m 'here is some metadata' > test.tdf
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -p \
             decrypt -f test.tdf > decrypted
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -p \
             metadata -f test.tdf > metadata
 
           if ! diff -q data decrypted; then
@@ -174,14 +174,14 @@ jobs:
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -p \
             encryptnano --kas-url=http://localhost:8080 --attr https://example.com/attr/attr1/value/value1 -f data -m 'here is some metadata' > nano.ntdf
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -p \
             decryptnano -f nano.ntdf > decrypted
           
           if ! diff -q data decrypted; then
@@ -216,7 +216,7 @@ jobs:
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -p \
             encrypt --kas-url=localhost:8080,localhost:8282 -f data -m 'here is some metadata' > test.tdf
 
           java -jar target/cmdline.jar \
@@ -230,7 +230,7 @@ jobs:
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -p \
             metadata -f test.tdf > metadata
 
           if ! diff -q data decrypted; then

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -138,21 +138,21 @@ jobs:
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i -p \
+            -i -h \
             encrypt --kas-url=localhost:8080 --mime-type=text/plain --attr https://example.com/attr/attr1/value/value1 --autoconfigure=false -f data -m 'here is some metadata' > test.tdf
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i -p \
+            -i -h \
             decrypt -f test.tdf > decrypted
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i -p \
+            -i -h \
             metadata -f test.tdf > metadata
 
           if ! diff -q data decrypted; then
@@ -174,14 +174,14 @@ jobs:
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i -p \
+            -i -h \
             encryptnano --kas-url=http://localhost:8080 --attr https://example.com/attr/attr1/value/value1 -f data -m 'here is some metadata' > nano.ntdf
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i -p \
+            -i -h \
             decryptnano -f nano.ntdf > decrypted
           
           if ! diff -q data decrypted; then
@@ -216,21 +216,21 @@ jobs:
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i -p \
+            -i -h \
             encrypt --kas-url=localhost:8080,localhost:8282 -f data -m 'here is some metadata' > test.tdf
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i \
+            -i -h \
             decrypt -f test.tdf > decrypted
 
           java -jar target/cmdline.jar \
             --client-id=opentdf-sdk \
             --client-secret=secret \
             --platform-endpoint=localhost:8080 \
-            -i -p \
+            -i -h \
             metadata -f test.tdf > metadata
 
           if ! diff -q data decrypted; then

--- a/cmdline/src/main/java/io/opentdf/platform/Command.java
+++ b/cmdline/src/main/java/io/opentdf/platform/Command.java
@@ -93,7 +93,6 @@ class Command {
     }
 
     private SDK buildSDK() {
-        // Create an SSLFactory with the TrustManager that trusts all certificates
         SDKBuilder builder = new SDKBuilder();
         if (insecure){
             SSLFactory sslFactory = SSLFactory.builder()

--- a/cmdline/src/main/java/io/opentdf/platform/Command.java
+++ b/cmdline/src/main/java/io/opentdf/platform/Command.java
@@ -42,7 +42,7 @@ class Command {
     @Option(names = {"--client-secret"}, required = true)
     private String clientSecret;
 
-    @Option(names = {"-p", "--plaintext"}, defaultValue = "false")
+    @Option(names = {"-h", "--plaintext"}, defaultValue = "false")
     private boolean plaintext;
 
     @Option(names = {"-i", "--insecure"}, defaultValue = "false")

--- a/cmdline/src/main/java/io/opentdf/platform/Command.java
+++ b/cmdline/src/main/java/io/opentdf/platform/Command.java
@@ -31,13 +31,21 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
+import nl.altindag.ssl.SSLFactory;
+import nl.altindag.ssl.util.TrustManagerUtils;
+
+import javax.net.ssl.TrustManager;
+
 @CommandLine.Command(name = "tdf")
 class Command {
 
     @Option(names = {"--client-secret"}, required = true)
     private String clientSecret;
 
-    @Option(names = {"-i", "--insecure-connection"}, defaultValue = "false")
+    @Option(names = {"-p", "--plaintext"}, defaultValue = "false")
+    private boolean plaintext;
+
+    @Option(names = {"-i", "--insecure"}, defaultValue = "false")
     private boolean insecure;
 
     @Option(names = {"--client-id"}, required = true)
@@ -63,6 +71,7 @@ class Command {
             ki.URL = k;
             return ki;
         }).toArray(Config.KASInfo[]::new);
+        
 
         List<Consumer<Config.TDFConfig>> configs = new ArrayList<>();
         configs.add(Config.withKasInformation(kasInfos));
@@ -84,10 +93,18 @@ class Command {
     }
 
     private SDK buildSDK() {
-        return new SDKBuilder()
-                .platformEndpoint(platformEndpoint)
+        // Create an SSLFactory with the TrustManager that trusts all certificates
+        SDKBuilder builder = new SDKBuilder();
+        if (insecure){
+            SSLFactory sslFactory = SSLFactory.builder()
+            .withUnsafeTrustMaterial() // Trust all certificates
+            .build();
+            builder.sslFactory(sslFactory);
+        }
+        
+        return  builder.platformEndpoint(platformEndpoint)
                 .clientSecret(clientId, clientSecret)
-                .useInsecurePlaintextConnection(insecure)
+                .useInsecurePlaintextConnection(plaintext)
                 .build();
     }
 


### PR DESCRIPTION
Currently --insecure forces http plaintext. Instead have --insecure use an ssl factory that does not check certs. Also add a flag for http plaintext (-h).