### PR TITLE
fix(lib): Adds a 10 MiB cap to manifest size

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDFReader.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDFReader.java
@@ -12,6 +12,9 @@ import static io.opentdf.platform.sdk.TDFWriter.TDF_PAYLOAD_FILE_NAME;
 
 public class TDFReader {
 
+    private static final int MAX_MANIFEST_SIZE_MB = 10;
+    private static final int BYTES_IN_MB = 1024 * 1024;
+    private static final int MAX_MANIFEST_SIZE_BYTES = MAX_MANIFEST_SIZE_MB * BYTES_IN_MB;
     private final ZipReader.Entry manifest;
     private final InputStream payload;
 
@@ -28,6 +31,10 @@ public class TDFReader {
         }
 
         manifest = entries.get(TDF_MANIFEST_FILE_NAME);
+        if (manifest.getFileSize() > MAX_MANIFEST_SIZE_BYTES) {
+            throw new SDKException("manifest file too large: " + (manifest.getFileSize() / (double) BYTES_IN_MB) + " MB");
+        }
+
         payload = entries.get(TDF_PAYLOAD_FILE_NAME).getData();
     }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ZipReader.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ZipReader.java
@@ -139,6 +139,10 @@ public class ZipReader {
         private final String fileName;
         final long offsetToLocalHeader;
 
+        public long getFileSize() {
+            return fileSize;
+        }
+
         private Entry(byte[] fileName, long offsetToLocalHeader, long fileSize) {
             this.fileName = new String(fileName, StandardCharsets.UTF_8);
             this.offsetToLocalHeader = offsetToLocalHeader;


### PR DESCRIPTION
Fixes https://github.com/opentdf/java-sdk/issues/155