### PR TITLE
chore: fix to deploy to GitHub Packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,18 +233,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Exclude from lifecycle, phase none -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -276,6 +264,19 @@
                     </snapshots>
                 </repository>
             </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>3.1.2</version>
+                        <configuration>
+                            <repositoryId>github-pkg</repositoryId>
+                            <url>https://maven.pkg.github.com/opentdf/java-sdk</url>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>release</id>
@@ -299,6 +300,18 @@
                             <!-- defined in settings.xml -->
                             <publishingServerId>central</publishingServerId>
                         </configuration>
+                    </plugin>
+                    <!-- Exclude from lifecycle, phase none -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>3.1.2</version>
+                        <executions>
+                            <execution>
+                                <id>default-deploy</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Update maven-deploy-plugin to be used during `stage` for deployment to GitHub Packages, this plugin is excluded from `release` to Maven Central

Replaced maven-deploy-plugin version 3.1.1 with 3.1.2 and added configuration for GitHub package repository. Restored lifecycle exclusion for default-deploy phase ensuring no impact on the build process.