### PR TITLE
chore: env.GITHUB_ACTOR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,8 @@ jobs:
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
           <servers><server>
           <id>github-pkg</id>
-          <username>${{ secrets.GITHUB_USERNAME }}</username>
-          <password>${{ secrets.GITHUB_TOKEN }}</password>
+          <username>${{ env.GITHUB_ACTOR }}</username>
+          <password>${{ env.GITHUB_TOKEN }}</password>
           </server></servers>
           </settings>
           EOF


### PR DESCRIPTION
Update GitHub credentials source in release workflow for `stage` profile

Changed the Maven settings to use environment variables instead of secrets for GitHub credentials. This enhances security by aligning with the recommended best practices for GitHub Actions.