### PR TITLE
chore: 0.7.2-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,18 @@ Create an account, link with GitHub, under User setting, Create a `token`
 [INFO]      [exec] 
 [INFO]      [exec] Please see https://buf.build/docs/bsr/rate-limits for details about BSR rate limiting.
 ```
+
+## Release Process
+
+### SNAPSHOT
+
+Snapshots are from main latest
+
+```shell
+mvn versions:set -DnewVersion=1.2.3-SNAPSHOT
+```
+
+### RELEASE
+
+Releases are from tags created by GitHub Release process.
+Release Please trigger the release process.

--- a/cmdline/pom.xml
+++ b/cmdline/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.opentdf.platform</groupId>
         <artifactId>sdk-pom</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
     <artifactId>cmdline</artifactId>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.opentdf.platform</groupId>
     <artifactId>sdk-pom</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.2-SNAPSHOT</version>
     <name>io.opentdf.platform:sdk-pom</name>
     <description>OpenTDF Java SDK</description>
     <url>https://github.com/opentdf/java-sdk</url>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>sdk-pom</artifactId>
         <groupId>io.opentdf.platform</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.7.2-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <dependencies>


### PR DESCRIPTION
Upgraded project versions from 0.7.0-SNAPSHOT to 0.7.2-SNAPSHOT across multiple POM files. Added detailed steps for the release process, including handling SNAPSHOT and RELEASE versions, in the README.md.

bump to very latest version, see https://github.com/opentdf/java-sdk/packages/2097221/versions