### PR TITLE
ci: SonarCloud coverage

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -53,6 +53,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
         with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -56,8 +56,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
         with:
-          java-version: "11"
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
           server-id: github
       - name: Maven Test Coverage
         env:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -42,11 +42,28 @@ jobs:
           distribution: "adopt"
           server-id: github
       - name: Maven Verify
-        run: |
-          mvn --batch-mode verify
+        run: mvn --batch-mode verify
         env:
           BUF_INPUT_HTTPS_USERNAME: opentdf-bot
           BUF_INPUT_HTTPS_PASSWORD: ${{ secrets.PERSONAL_ACCESS_TOKEN_OPENTDF }}
+
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Set up JDK
+        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          server-id: github
+      - name: Maven Test Coverage
+        env:
+          BUF_INPUT_HTTPS_USERNAME: opentdf-bot
+          BUF_INPUT_HTTPS_PASSWORD: ${{ secrets.PERSONAL_ACCESS_TOKEN_OPENTDF }}
+        run: mvn --batch-mode clean sonar:sonar -P coverage
 
   platform-integration:
     runs-on: ubuntu-22.04

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -63,7 +63,7 @@ jobs:
         env:
           BUF_INPUT_HTTPS_USERNAME: opentdf-bot
           BUF_INPUT_HTTPS_PASSWORD: ${{ secrets.PERSONAL_ACCESS_TOKEN_OPENTDF }}
-        run: mvn --batch-mode clean sonar:sonar -P coverage
+        run: mvn --batch-mode clean verify -P coverage
 
   platform-integration:
     runs-on: ubuntu-22.04

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -277,6 +277,7 @@ jobs:
       - platform-integration
       - platform-xtest
       - mavenverify
+      - sonarcloud
       - pr
     runs-on: ubuntu-latest
     if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,11 @@
         </profile>
         <profile>
             <id>coverage</id>
+            <properties>
+                <sonar.organization>opentdf</sonar.organization>
+                <sonar.projectKey>opentdf_java-sdk</sonar.projectKey>
+                <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -342,5 +342,36 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.12</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,9 @@
         </profile>
         <profile>
             <id>coverage</id>
+            <modules>
+                <module>sdk</module>
+            </modules>
             <properties>
                 <sonar.organization>opentdf</sonar.organization>
                 <sonar.projectKey>opentdf_java-sdk</sonar.projectKey>
@@ -360,10 +363,12 @@
                                 <id>prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
+                                    <goal>report-aggregate</goal>
                                 </goals>
                             </execution>
                             <execution>
                                 <id>report</id>
+                                <phase>test</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
@@ -372,6 +377,13 @@
                                         <format>XML</format>
                                     </formats>
                                 </configuration>
+                            </execution>
+                            <execution>
+                                <id>post-test-report</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,7 @@
                                     <goal>report</goal>
                                 </goals>
                                 <configuration>
+                                    <dataFile>${project.parent.basedir}/target/jacoco.exec</dataFile>
                                     <formats>
                                         <format>XML</format>
                                     </formats>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -275,6 +275,35 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${project.parent.basedir}/target/jacoco.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.parent.basedir}/target/jacoco.exec</dataFile>
+                            <formats>
+                                <format>XML</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Introduce a new Maven profile for JaCoCo test coverage reporting in the `pom.xml`. Additionally, update the GitHub Actions workflow to include a SonarCloud scan that uses the JaCoCo coverage data.

DSP-119
DSP-120