### PR TITLE
feat(sdk): adds Collections API

### DIFF
--- a/examples/src/main/java/io/opentdf/platform/DecryptCollectionExample.java
+++ b/examples/src/main/java/io/opentdf/platform/DecryptCollectionExample.java
@@ -1,0 +1,41 @@
+package io.opentdf.platform;
+
+import io.opentdf.platform.sdk.Config;
+import io.opentdf.platform.sdk.NanoTDF;
+import io.opentdf.platform.sdk.SDK;
+import io.opentdf.platform.sdk.SDKBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+
+public class DecryptCollectionExample {
+    public static void main(String[] args) throws IOException, NanoTDF.NanoTDFMaxSizeLimit, NanoTDF.UnsupportedNanoTDFFeature, NanoTDF.InvalidNanoTDFConfig, NoSuchAlgorithmException, InterruptedException {
+        String clientId = "opentdf-sdk";
+        String clientSecret = "secret";
+        String platformEndpoint = "localhost:8080";
+
+        SDKBuilder builder = new SDKBuilder();
+        SDK sdk = builder.platformEndpoint(platformEndpoint)
+                .clientSecret(clientId, clientSecret).useInsecurePlaintextConnection(true)
+                .build();
+
+        var kasInfo = new Config.KASInfo();
+        kasInfo.URL = "http://localhost:8080/kas";
+
+
+        // Convert String to InputStream
+        NanoTDF nanoTDFClient = new NanoTDF(true);
+
+        for (int i = 0; i < 50; i++) {
+            FileInputStream fis = new FileInputStream(String.format("out/my.%d_ciphertext", i));
+            nanoTDFClient.readNanoTDF(ByteBuffer.wrap(fis.readAllBytes()), System.out, sdk.getServices().kas());
+            fis.close();
+        }
+
+    }
+}

--- a/examples/src/main/java/io/opentdf/platform/EncryptCollectionExample.java
+++ b/examples/src/main/java/io/opentdf/platform/EncryptCollectionExample.java
@@ -1,0 +1,49 @@
+package io.opentdf.platform;
+
+import io.opentdf.platform.sdk.Config;
+import io.opentdf.platform.sdk.NanoTDF;
+import io.opentdf.platform.sdk.SDK;
+import io.opentdf.platform.sdk.SDKBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+
+public class EncryptCollectionExample {
+    public static void main(String[] args) throws IOException, NanoTDF.NanoTDFMaxSizeLimit, NanoTDF.UnsupportedNanoTDFFeature, NanoTDF.InvalidNanoTDFConfig, NoSuchAlgorithmException, InterruptedException {
+        String clientId = "opentdf-sdk";
+        String clientSecret = "secret";
+        String platformEndpoint = "localhost:8080";
+
+        SDKBuilder builder = new SDKBuilder();
+        SDK sdk = builder.platformEndpoint(platformEndpoint)
+                .clientSecret(clientId, clientSecret).useInsecurePlaintextConnection(true)
+                .build();
+
+        var kasInfo = new Config.KASInfo();
+        kasInfo.URL = "http://localhost:8080/kas";
+
+        var tdfConfig = Config.newNanoTDFConfig(
+                Config.withNanoKasInformation(kasInfo),
+                Config.witDataAttributes("https://example.com/attr/attr1/value/value1"),
+                Config.withCollection()
+        );
+
+        String str = "Hello, World!";
+
+        // Convert String to InputStream
+        var in = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        NanoTDF nanoTDFClient = new NanoTDF();
+
+        for (int i = 0; i < 50; i++) {
+            FileOutputStream fos = new FileOutputStream(String.format("out/my.%d_ciphertext", i));
+            nanoTDFClient.createNanoTDF(ByteBuffer.wrap(str.getBytes()), fos, tdfConfig,
+                    sdk.getServices().kas());
+        }
+
+    }
+}

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
@@ -35,7 +35,7 @@ public class NanoTDF {
     private final CollectionStore collectionStore;
 
     public NanoTDF() {
-        this(null);
+        this(new CollectionStore.NoOpCollectionStore());
     }
 
     public NanoTDF(boolean collectionStoreEnabled) {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/CollectionStore.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/CollectionStore.java
@@ -1,0 +1,9 @@
+package io.opentdf.platform.sdk.nanotdf;
+
+import io.opentdf.platform.sdk.NanoTDF;
+
+public interface CollectionStore {
+    public static final NanoTDF.CollectionKey NO_PRIVATE_KEY = new NanoTDF.CollectionKey(null);
+    void store(Header header, NanoTDF.CollectionKey key);
+    NanoTDF.CollectionKey getKey(Header header);
+}

--- a/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/CollectionStore.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/CollectionStore.java
@@ -3,7 +3,19 @@ package io.opentdf.platform.sdk.nanotdf;
 import io.opentdf.platform.sdk.NanoTDF;
 
 public interface CollectionStore {
-    public static final NanoTDF.CollectionKey NO_PRIVATE_KEY = new NanoTDF.CollectionKey(null);
+    NanoTDF.CollectionKey NO_PRIVATE_KEY = new NanoTDF.CollectionKey(null);
     void store(Header header, NanoTDF.CollectionKey key);
     NanoTDF.CollectionKey getKey(Header header);
+
+    class NoOpCollectionStore implements CollectionStore {
+        public NoOpCollectionStore() {}
+
+        @Override
+        public void store(Header header, NanoTDF.CollectionKey key) {}
+
+        @Override
+        public NanoTDF.CollectionKey getKey(Header header) {
+            return NO_PRIVATE_KEY;
+        }
+    }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/CollectionStoreImpl.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/CollectionStoreImpl.java
@@ -1,0 +1,30 @@
+package io.opentdf.platform.sdk.nanotdf;
+
+import io.opentdf.platform.sdk.NanoTDF;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class CollectionStoreImpl extends LinkedHashMap<ByteBuffer, NanoTDF.CollectionKey>
+        implements CollectionStore {
+    private static final int MAX_SIZE_STORE = 500;
+
+    public CollectionStoreImpl() {}
+
+    public synchronized void store(Header header, NanoTDF.CollectionKey key) {
+        ByteBuffer buf = ByteBuffer.allocate(header.getTotalSize());
+        header.writeIntoBuffer(buf);
+        super.put(buf, key);
+    }
+
+    public synchronized NanoTDF.CollectionKey getKey(Header header) {
+        ByteBuffer buf = ByteBuffer.allocate(header.getTotalSize());
+        header.writeIntoBuffer(buf);
+        return super.getOrDefault(buf, NO_PRIVATE_KEY);
+    }
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<ByteBuffer, NanoTDF.CollectionKey> eldest) {
+        return this.size() > MAX_SIZE_STORE;
+    }
+}

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
@@ -154,4 +154,45 @@ public class NanoTDFTest {
             assertThat(dataStream.toByteArray()).isEqualTo(data);
         }
     }
+
+    @Test
+    void collection() throws Exception {
+        var kasInfos = new ArrayList<>();
+        var kasInfo = new Config.KASInfo();
+        kasInfo.URL = "https://api.example.com/kas";
+        kasInfo.PublicKey = null;
+        kasInfo.KID = KID;
+        kasInfos.add(kasInfo);
+
+        Config.NanoTDFConfig config = Config.newNanoTDFConfig(
+                Config.withNanoKasInformation(kasInfos.toArray(new Config.KASInfo[0])),
+                Config.witDataAttributes("https://example.com/attr/Classification/value/S",
+                        "https://example.com/attr/Classification/value/X"),
+                Config.withCollection()
+        );
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[]{});
+
+        NanoTDF nanoTDF = new NanoTDF();
+        ByteBuffer header = getHeaderBuffer(byteBuffer,nanoTDF, config);
+        for (int i = 0; i < Config.MAX_COLLECTION_ITERATION - 10; i++) {
+            config.collectionConfig.getHeaderInfo();
+
+        }
+        for (int i = 1; i < 10; i++) {
+            ByteBuffer newHeader = getHeaderBuffer(byteBuffer,nanoTDF, config);
+            assertThat(header).isEqualTo(newHeader);
+        }
+
+        ByteBuffer newHeader = getHeaderBuffer(byteBuffer,nanoTDF, config);
+        assertThat(header).isNotEqualTo(newHeader);
+    }
+
+    private ByteBuffer getHeaderBuffer(ByteBuffer input, NanoTDF nanoTDF, Config.NanoTDFConfig config) throws Exception {
+        ByteArrayOutputStream tdfOutputStream = new ByteArrayOutputStream();
+        nanoTDF.createNanoTDF(input, tdfOutputStream, config, kas);
+        ByteBuffer tdf = ByteBuffer.wrap(tdfOutputStream.toByteArray());
+        Header header = new Header(tdf);
+        return tdf.position(0).slice().limit(header.getTotalSize());
+    }
 }


### PR DESCRIPTION
Adds Collection API to NanoTDF. 

Decrypt: NanoTDF Client constructor will have a option to enable `CollectionStore` or pass in a custom `CollectionStore` implementation.

Encrypt: NanoTDFConfig will have an option `WithCollection` to enable writing as a Collection rather as individual NanoTDF's. 

Examples for Collection are made in `ExampleEncryptCollection` and `ExampleDecryptCollection` and will successfully encrypt/decrypt with default OpenTDF Platform Fixtures. ExampleDecryptCollection will have only 1 Unwrap Request to Platform.