### PR TITLE
fix: Use reusable start-additional-kas workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -225,21 +225,12 @@ jobs:
           fi
         working-directory: cmdline
 
-      - uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635
-        name: start another KAS server in background
+      - name: Start additional kas
+        uses: opentdf/platform/test/start-additional-kas@main
         with:
-          run: >
-            <opentdf.yaml >opentdf-beta.yaml yq e '
-              (.server.port = 8282)
-              | (.mode = ["kas"])
-              | (.sdk_config = {"endpoint":"http://localhost:8080","plaintext":true,"client_id":"opentdf","client_secret":"secret"})
-            '
-            && go run ./service --config-file ./opentdf-beta.yaml start
-          wait-on: |
-            tcp:localhost:8282
-          log-output-if: true
-          wait-for: 90s
-          working-directory: platform
+          kas-port: 8282
+          kas-name: beta
+
       - name: Make sure that the second platform is up
         run: |
           grpcurl -plaintext localhost:8282 kas.AccessService/PublicKey


### PR DESCRIPTION
Reduce loc, limit places to update kas mode code/configs