### PR TITLE
fix(sdk): deserialize object statement values correctly

### DIFF
--- a/cmdline/src/main/java/io/opentdf/platform/Command.java
+++ b/cmdline/src/main/java/io/opentdf/platform/Command.java
@@ -267,8 +267,7 @@ class Command {
                     opts.add(Config.withDisableAssertionVerification(true));
                 }
 
-                var arrayOpts = (Consumer<Config.TDFReaderConfig>[])opts.toArray();
-                var readerConfig = Config.newTDFReaderConfig(arrayOpts);
+                var readerConfig = Config.newTDFReaderConfig(opts.toArray(new Consumer[0]));
                 var reader = new TDF().loadTDF(in, sdk.getServices().kas(), readerConfig);
                 reader.readPayload(stdout);
             }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
@@ -322,7 +322,6 @@ public class Manifest {
         public String appliesToState;
         public AssertionConfig.Statement statement;
         public Binding binding;
-
         static public class HashValues {
             private final String assertionHash;
             private final String signature;
@@ -492,12 +491,7 @@ public class Manifest {
                     statement.value = value.getAsString();
                 } else {
                     assert value.isJsonObject();
-                    var valueJson = value.toString();
-                    try {
-                        statement.value = new JsonCanonicalizer(valueJson).getEncodedString();
-                    } catch (IOException e) {
-                        throw new SDKException("error canonicalizing JSON", e);
-                    }
+                    statement.value = value.toString();
                 }
             }
             return statement;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
@@ -8,12 +8,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -490,7 +486,10 @@ public class Manifest {
                 statement.schema = obj.get("schema").getAsString();
             }
             if (obj.has("value")) {
-                statement.value = obj.get("value").toString();
+                var value = obj.get("value");
+                statement.value = value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()
+                        ? value.getAsString()
+                        : value.toString();
             }
             return statement;
         }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
@@ -487,10 +487,9 @@ public class Manifest {
             if (obj.has("value")) {
                 var value = obj.get("value");
                 if (value.isJsonPrimitive()) {
-                    assert value.getAsJsonPrimitive().isString();
+                    // it's already a primitive (hopefully string) so we don't need its escaped value here
                     statement.value = value.getAsString();
                 } else {
-                    assert value.isJsonObject();
                     statement.value = value.toString();
                 }
             }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -7,13 +7,11 @@ import com.nimbusds.jose.*;
 import io.opentdf.platform.policy.Value;
 import io.opentdf.platform.policy.attributes.AttributesServiceGrpc.AttributesServiceFutureStub;
 import io.opentdf.platform.sdk.Config.TDFConfig;
-import io.opentdf.platform.sdk.Manifest.ManifestDeserializer;
 import io.opentdf.platform.sdk.Autoconfigure.AttributeValueFQN;
 import io.opentdf.platform.sdk.Config.KASInfo;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.erdtman.jcs.JsonCanonicalizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,9 +77,7 @@ public class TDF {
 
     private static final SecureRandom sRandom = new SecureRandom();
 
-    private static final Gson gson = new GsonBuilder()
-                                        .registerTypeAdapter(Manifest.class, new ManifestDeserializer())
-                                        .create();
+    private static final Gson gson = new GsonBuilder().create();
 
     public class SplitKeyException extends IOException {
         public SplitKeyException(String errorMessage) {
@@ -561,7 +557,7 @@ public class TDF {
         }
 
         tdfObject.manifest.assertions = signedAssertions;
-        String manifestAsStr = gson.toJson(tdfObject.manifest);
+        String manifestAsStr = Manifest.toJson(tdfObject.manifest);
 
         tdfWriter.appendManifest(manifestAsStr);
         tdfObject.size = tdfWriter.finish();

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -533,7 +533,6 @@ public class TDF {
             assertion.type = assertionConfig.type.toString();
             assertion.scope = assertionConfig.scope.toString();
             assertion.statement = assertionConfig.statement;
-            assertion.statement.format = "string";
             assertion.appliesToState = assertionConfig.appliesToState.toString();
 
             var assertionHashAsHex = assertion.hash();

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -533,6 +533,7 @@ public class TDF {
             assertion.type = assertionConfig.type.toString();
             assertion.scope = assertionConfig.scope.toString();
             assertion.statement = assertionConfig.statement;
+            assertion.statement.format = "string";
             assertion.appliesToState = assertionConfig.appliesToState.toString();
 
             var assertionHashAsHex = assertion.hash();

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ManifestTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ManifestTest.java
@@ -9,7 +9,7 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -153,7 +153,7 @@ public class ManifestTest {
     }
 
     @Test
-    public void testReadingManifestWithObjectStatementValue() throws IOException {
+    void testReadingManifestWithObjectStatementValue() throws IOException {
         final Manifest manifest;
         try (var mStream = getClass().getResourceAsStream("/io.opentdf.platform.sdk.TestData/manifest-with-object-statement-value.json")) {
             assert mStream != null;

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ManifestTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ManifestTest.java
@@ -11,8 +11,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ManifestTest {
     @Test
@@ -68,7 +66,7 @@ public class ManifestTest {
 
         // Test payload
         assertEquals(manifest.payload.url, "0.payload");
-        assertTrue(manifest.payload.isEncrypted);
+        assertThat(manifest.payload.isEncrypted).isTrue();
 
         // Test encryptionInformation
         assertEquals(manifest.encryptionInformation.keyAccessType, "split");
@@ -146,9 +144,9 @@ public class ManifestTest {
 
         // Test payload for sanity check
         assertEquals(manifest.payload.url, "0.payload");
-        assertTrue(manifest.payload.isEncrypted);
+        assertThat(manifest.payload.isEncrypted).isTrue();
         // Test assertion deserialization
-        assertNotNull(manifest.assertions);
+        assertThat(manifest.assertions).isNotNull();
         assertEquals(manifest.assertions.size(), 0);
     }
 

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ZipReaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ZipReaderTest.java
@@ -1,8 +1,6 @@
 package io.opentdf.platform.sdk;
-import com.google.gson.GsonBuilder;
 
-import io.opentdf.platform.sdk.Manifest.ManifestDeserializer;
-
+import com.google.gson.Gson;
 import org.apache.commons.compress.archivers.zip.Zip64Mode;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
@@ -22,9 +20,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ZipReaderTest {
 
@@ -47,9 +42,7 @@ public class ZipReaderTest {
             if (entry.getName().endsWith(".json")) {
                 entry.getData().transferTo(stream);
                 var data = stream.toString(StandardCharsets.UTF_8);
-                var gson = new GsonBuilder()
-                                    .registerTypeAdapter(Manifest.class, new ManifestDeserializer())
-                                    .create();
+                var gson = new Gson();
                 var map = gson.fromJson(data, Map.class);
                 
                 if (test) {

--- a/sdk/src/test/resources/io.opentdf.platform.sdk.TestData/manifest-with-object-statement-value.json
+++ b/sdk/src/test/resources/io.opentdf.platform.sdk.TestData/manifest-with-object-statement-value.json
@@ -1,0 +1,129 @@
+{
+  "payload": {
+    "type": "reference",
+    "url": "0.payload",
+    "protocol": "zip",
+    "isEncrypted": true,
+    "mimeType": "text/plain",
+    "tdf_spec_version": null
+  },
+  "encryptionInformation": {
+    "type": "split",
+    "keyAccess": [
+      {
+        "type": "wrapped",
+        "url": "https://virtru-eng-kas.apps.dsp.shp.virtru.us/kas",
+        "protocol": "kas",
+        "wrappedKey": "z88k9ZYiu6aMz/3BYvS7+K89EYFN/r2/uZ2XdoIOLdk6fa/5FkNgKIy1KcHL4e+cLQEJagOoqB6X7drGRCxpBNh2GLcKnSxjkvCipVNVY03o+QMhXKBf1xx5ZtFokRHxkflAYlHrTtF5cN25RbSLTUso9zB6Jex3p9mnjYeN3b1BjarkKn6//hKjQFYAGWFygFMaM+iNXBO6dAcTg204RI4h+cAk404lYvN2FGW4wZOu0igi8Es80vcYm3WQT/h3MrNqxN5EMuvrF8tmviSwUH/EpHw4s+5YgAuZIheBPujURhnbq+YKJuAl30ro/POUO60TrTcTmkpaLswQBCBeLg==",
+        "sid": null,
+        "kid": "r1",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "MmZjN2RhNjM1ZTEyNWM4NjVhYTQwYWQzNjcyYWRiZGViYTdlNDA1ZTVkOTAyZGViNmQwM2Q1ZWIxNDM3NTE5Ng=="
+        },
+        "encryptedMetadata": null
+      },
+      {
+        "type": "wrapped",
+        "url": "https://platform-dsp-pep-qa.apps.dsp.shp.virtru.us/kas",
+        "protocol": "kas",
+        "wrappedKey": "FZ5lGT9qG5fQJ16v+gCM9huPavBhh/ooPfFw36wJkW+KwPlnOkBvJuTVq9S7iUzUKgfGSd80TxfvVCS0qds4gFS+oAKxKg/CSVILbyyPYaNgpR8/dFFKAFb2w/9xhocE1uvfrQkyXrDAnyAgNRNm1ecpGkYuOrjPCb++v+6+DjQxscQcBuMzG8J5lRMB/VdME1VtT/VCZ4JGZcpXJfDKnZjYY/6fUFGLK7sOTYLo5nmVvapDLsmaQXFyBfo30oDbsnPTofk1EMT5DMrv5H6UlK7YiGda9OTsQK6t0yrK84oBoTRJmH4BEMs7oDeFDzNZGHp8bjq/IWF/zzu/haRMZw==",
+        "sid": null,
+        "kid": "r1",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "MmZjN2RhNjM1ZTEyNWM4NjVhYTQwYWQzNjcyYWRiZGViYTdlNDA1ZTVkOTAyZGViNmQwM2Q1ZWIxNDM3NTE5Ng=="
+        },
+        "encryptedMetadata": null
+      }
+    ],
+    "method": {
+      "algorithm": "AES-256-GCM",
+      "isStreamable": true,
+      "iv": null
+    },
+    "integrityInformation": {
+      "rootSignature": {
+        "alg": "HS256",
+        "sig": "MjM2NjAzMjZiNWJhODdhYTc4OGJmODJlZWM5YmExYmRmN2Q4YjUzYzVkOWI1NmI1MmM1MDBmNTY2OWNkZTUxYw=="
+      },
+      "segmentSizeDefault": 104857600,
+      "segmentHashAlg": "GMAC",
+      "segments": [
+        {
+          "hash": "ZDZlYjg0ZjhjYWMyMmU5YmNiZTdhYmJhMDcwMTk4NTg=",
+          "segmentSize": 24,
+          "encryptedSegmentSize": 52
+        }
+      ],
+      "encryptedSegmentSizeDefault": 104857628
+    },
+    "policy": "eyJ1dWlkIjoiMzI5NDZhNTctYjJiZS00M2JmLWFhY2YtZjVjMjZlYzYxY2E0IiwiYm9keSI6eyJkYXRhQXR0cmlidXRlcyI6W3siZGVzY3JpcHRpb24iOm51bGwsInR5cGUiOm51bGwsImF0dHJpYnV0ZSI6Imh0dHBzOi8vZGVtby5jb20vYXR0ci9yZWx0by92YWx1ZS91c2EiLCJkaXNwbGF5TmFtZSI6bnVsbCwia2FzVVJMIjoiaHR0cHM6Ly92aXJ0cnUtZW5nLWthcy5hcHBzLmRzcC5zaHAudmlydHJ1LnVzL2thcyxodHRwczovL3BsYXRmb3JtLWRzcC1wZXAtcWEuYXBwcy5kc3Auc2hwLnZpcnRydS51cy9rYXMiLCJwdWJLZXkiOm51bGwsImlzRGVmYXVsdCI6bnVsbH0seyJkZXNjcmlwdGlvbiI6bnVsbCwidHlwZSI6bnVsbCwiYXR0cmlidXRlIjoiaHR0cHM6Ly9kZW1vLmNvbS9hdHRyL2NsYXNzaWZpY2F0aW9uL3ZhbHVlL3NlY3JldCIsImRpc3BsYXlOYW1lIjpudWxsLCJrYXNVUkwiOiJodHRwczovL3ZpcnRydS1lbmcta2FzLmFwcHMuZHNwLnNocC52aXJ0cnUudXMva2FzLGh0dHBzOi8vcGxhdGZvcm0tZHNwLXBlcC1xYS5hcHBzLmRzcC5zaHAudmlydHJ1LnVzL2thcyIsInB1YktleSI6bnVsbCwiaXNEZWZhdWx0IjpudWxsfV0sImRpc3NlbSI6W119fQ=="
+  },
+  "assertions": [
+    {
+      "id": "bacbe31eab384df39d35a5fbe83778de",
+      "type": "handling",
+      "scope": "tdo",
+      "appliesToState": null,
+      "statement": {
+        "format": "json-structured",
+        "value": {
+          "ocl": {
+            "pol": "2ccf11cb-6c9a-4e49-9746-a7f0a295945d",
+            "cls": "SECRET",
+            "catl": [
+              {
+                "type": "P",
+                "name": "Releasable To",
+                "vals": [
+                  "usa"
+                ]
+              }
+            ],
+            "dcr": "2024-12-17T13:00:52Z"
+          },
+          "context": {
+            "@base": "urn:nato:stanag:5636:A:1:elements:json"
+          }
+        }
+      },
+      "binding": {
+        "method": "jws",
+        "signature": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJDb25maWRlbnRpYWxpdHlJbmZvcm1hdGlvbiI6InsgXCJvY2xcIjogeyBcInBvbFwiOiBcIjJjY2YxMWNiLTZjOWEtNGU0OS05NzQ2LWE3ZjBhMjk1OTQ1ZFwiLCBcImNsc1wiOiBcIlNFQ1JFVFwiLCBcImNhdGxcIjogWyB7IFwidHlwZVwiOiBcIlBcIiwgXCJuYW1lXCI6IFwiUmVsZWFzYWJsZSBUb1wiLCBcInZhbHNcIjogWyBcInVzYVwiIF0gfSBdLCBcImRjclwiOiBcIjIwMjQtMTItMTdUMTM6MDA6NTJaXCIgfSwgXCJjb250ZXh0XCI6IHsgXCJAYmFzZVwiOiBcInVybjpuYXRvOnN0YW5hZzo1NjM2OkE6MTplbGVtZW50czpqc29uXCIgfSB9In0.LlOzRLKKXMAqXDNsx9Ha5915CGcAkNLuBfI7jJmx6CnfQrLXhlRHWW3_aLv5DPsKQC6vh9gDQBH19o7q7EcukvK4IabA4l0oP8ePgHORaajyj7ONjoeudv_zQ9XN7xU447S3QznzOoasuWAFoN4682Fhf99Kjl6rhDCzmZhTwQw9drP7s41nNA5SwgEhoZj-X9KkNW5GbWjA95eb8uVRRWk8dOnVje6j8mlJuOtKdhMxQ8N5n0vBYYhiss9c4XervBjWAxwAMdbRaQN0iPZtMzIkxKLYxBZDvTnYSAqzpvfGPzkSI-Ze_hUZs2hp-ADNnYUJBf_LzFmKyqHjPSFQ7A"
+      }
+    },
+    {
+      "id": "ab43266781e64b51a4c52ffc44d6152c",
+      "type": "handling",
+      "scope": "payload",
+      "appliesToState": null,
+      "statement": {
+        "format": "json-structured",
+        "value": {
+          "ocl": {
+            "pol": "2ccf11cb-6c9a-4e49-9746-a7f0a295945d",
+            "cls": "SECRET",
+            "catl": [
+              {
+                "type": "P",
+                "name": "Releasable To",
+                "vals": [
+                  "usa"
+                ]
+              }
+            ],
+            "dcr": "2024-12-17T13:00:52Z"
+          },
+          "context": {
+            "@base": "urn:nato:stanag:5636:A:1:elements:json"
+          }
+        }
+      },
+      "binding": {
+        "method": "jws",
+        "signature": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJDb25maWRlbnRpYWxpdHlJbmZvcm1hdGlvbiI6InsgXCJvY2xcIjogeyBcInBvbFwiOiBcIjJjY2YxMWNiLTZjOWEtNGU0OS05NzQ2LWE3ZjBhMjk1OTQ1ZFwiLCBcImNsc1wiOiBcIlNFQ1JFVFwiLCBcImNhdGxcIjogWyB7IFwidHlwZVwiOiBcIlBcIiwgXCJuYW1lXCI6IFwiUmVsZWFzYWJsZSBUb1wiLCBcInZhbHNcIjogWyBcInVzYVwiIF0gfSBdLCBcImRjclwiOiBcIjIwMjQtMTItMTdUMTM6MDA6NTJaXCIgfSwgXCJjb250ZXh0XCI6IHsgXCJAYmFzZVwiOiBcInVybjpuYXRvOnN0YW5hZzo1NjM2OkE6MTplbGVtZW50czpqc29uXCIgfSB9IiwiUGF5bG9hZFNoYTI1NiI6IjlRMHVNZW9WTnVEVlVBVmxaelpMSjVMSzFTSkI3bjVHeUU1Rnp4bWh2WFU9In0.PZ2VF22D-MDIhgHvTKQmABE5AFpYr89q5iq9QIeIcx-lYN9NF0mptWWdVtrOog16NXJF5WZlwGXkMpiSJ2N16lQjRkc48MobHOwHMW3IU5sTeEWsPS9jc5SLh8HziKPKnHBlPWkrEGY_QUifkXFOgHihuXnZh1mcMxZt03mP3VeFuGRoWl_ZfhT6UT0oTDtZL4bobMODUYzCLCiCPMAE1AOqepWQBxRf55tqAAYTY5pvhO5CwXSenQTIowDfy7ULPPc_Kee8g59s4Xwe7-7d7mAcf30R3cKa5JZffE3p6W1dUh4OZp2N7wprXlCZYXZ5qWW6o8ACtXrmC8MzWj7Jjg"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Some SDKs don't set assertion values as objects instead of strings so we set them to string values when we deserialize

Also:
* encapsulate the `gson` instance that we use for `Manifest` deserialization so that we don't have to 
keep setting the options in different places
* remove the `ManifestDeserializer` since its purpose is to make the `assertions` list non-null but since
we have encapsulated the deserialization we can set it there
* add a setting to ignore assertions in the `cmdline` app so that we can do so in xtests

