### PR TITLE
chore:  Update CODEOWNERS to include @opentdf/security for helping with Dependabot

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,9 @@
 
 CODEOWNERS     @opentdf/architecture @opentdf/security
 LICENSE        @opentdf/architecture
+
+# @opentdf/security added on 2025-02-04 pom.xml
+examples/pom.xml @opentdf/java-sdk @opentdf/architecture @opentdf/security
+pom.xml @opentdf/java-sdk @opentdf/architecture @opentdf/security
+cmdline/pom.xml @opentdf/java-sdk @opentdf/architecture @opentdf/security
+sdk/pom.xml @opentdf/java-sdk @opentdf/architecture @opentdf/security


### PR DESCRIPTION
This PR updates CODEOWNERS to include @opentdf/security for files:
 * examples/pom.xml
 * pom.xml
 * cmdline/pom.xml
 * sdk/pom.xml