### PR TITLE
feat(sdk):  EC-wrapped key support for ZTDF

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -61,6 +61,11 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
     </dependency>
+      <dependency>
+          <groupId>commons-cli</groupId>
+          <artifactId>commons-cli</artifactId>
+          <version>1.4</version>
+      </dependency>
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>

--- a/examples/src/main/java/io/opentdf/platform/DecryptExample.java
+++ b/examples/src/main/java/io/opentdf/platform/DecryptExample.java
@@ -1,13 +1,12 @@
 package io.opentdf.platform;
+
 import io.opentdf.platform.sdk.*;
 import java.nio.file.StandardOpenOption;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import com.nimbusds.jose.JOSEException;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -15,14 +14,33 @@ import java.text.ParseException;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import org.apache.commons.cli.*;
 import org.apache.commons.codec.DecoderException;
-
 
 public class DecryptExample {
     public static void main(String[] args) throws IOException,
-    InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException,
-    BadPaddingException, InvalidKeyException, TDF.FailedToCreateGMAC,
-    JOSEException, ParseException, NoSuchAlgorithmException, DecoderException {
+            InvalidAlgorithmParameterException, NoSuchPaddingException, IllegalBlockSizeException,
+            BadPaddingException, InvalidKeyException, TDF.FailedToCreateGMAC,
+            JOSEException, ParseException, NoSuchAlgorithmException, DecoderException, org.apache.commons.cli.ParseException {
+
+        // Create Options object
+        Options options = new Options();
+
+        // Add rewrap encapsulation algorithm option
+        options.addOption(Option.builder("A")
+                .longOpt("rewrap-encapsulation-algorithm")
+                .hasArg()
+                .desc("Key wrap response algorithm algorithm:parameters")
+                .build());
+
+        // Parse command line arguments
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = parser.parse(options, args);
+
+        // Get the rewrap encapsulation algorithm
+        String rewrapEncapsulationAlgorithm = cmd.getOptionValue("rewrap-encapsulation-algorithm", "rsa:2048");
+        var sessionKeyType = KeyType.fromString(rewrapEncapsulationAlgorithm.toLowerCase());
+
 
         String clientId = "opentdf";
         String clientSecret = "secret";
@@ -35,8 +53,11 @@ public class DecryptExample {
 
         Path path = Paths.get("my.ciphertext");
         try (var in = FileChannel.open(path, StandardOpenOption.READ)) {
-            var reader = new TDF().loadTDF(in, sdk.getServices().kas());
+            var reader = new TDF().loadTDF(in, sdk.getServices().kas(), Config.newTDFReaderConfig(Config.WithSessionKeyType(sessionKeyType)));
             reader.readPayload(System.out);
         }
+
+        // Print the rewrap encapsulation algorithm
+        System.out.println("Rewrap Encapsulation Algorithm: " + rewrapEncapsulationAlgorithm);
     }
 }

--- a/examples/src/main/java/io/opentdf/platform/EncryptExample.java
+++ b/examples/src/main/java/io/opentdf/platform/EncryptExample.java
@@ -1,18 +1,35 @@
 package io.opentdf.platform;
+
 import io.opentdf.platform.sdk.*;
 import java.io.ByteArrayInputStream;
-import java.io.BufferedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.io.FileOutputStream;
-
 import com.nimbusds.jose.JOSEException;
+import org.apache.commons.cli.*;
 import org.apache.commons.codec.DecoderException;
-
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 public class EncryptExample {
-    public static void main(String[] args) throws IOException, JOSEException, AutoConfigureException, InterruptedException, ExecutionException, DecoderException {
+    public static void main(String[] args) throws IOException, JOSEException, AutoConfigureException,
+            InterruptedException, ExecutionException, DecoderException, ParseException {
+        // Create Options object
+        Options options = new Options();
+
+        // Add key encapsulation algorithm option
+        options.addOption(Option.builder("A")
+                .longOpt("key-encapsulation-algorithm")
+                .hasArg()
+                .desc("Key wrap algorithm algorithm:parameters")
+                .build());
+
+        // Parse command line arguments
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = parser.parse(options, args);
+
+        // Get the key encapsulation algorithm
+        String keyEncapsulationAlgorithm = cmd.getOptionValue("key-encapsulation-algorithm", "rsa:2048");
+
         String clientId = "opentdf";
         String clientSecret = "secret";
         String platformEndpoint = "localhost:8080";
@@ -25,17 +42,19 @@ public class EncryptExample {
         var kasInfo = new Config.KASInfo();
         kasInfo.URL = "http://localhost:8080/kas";
 
-        var tdfConfig = Config.newTDFConfig(Config.withKasInformation(kasInfo), Config.withDataAttributes("https://example.com/attr/color/value/red"));
-
+        var wrappingKeyType = KeyType.fromString(keyEncapsulationAlgorithm.toLowerCase());
+        var tdfConfig = Config.newTDFConfig(Config.withKasInformation(kasInfo),
+                Config.withDataAttributes("https://example.com/attr/color/value/red"),
+                Config.WithWrappingKeyAlg(wrappingKeyType));
         String str = "Hello, World!";
-        
+
         // Convert String to InputStream
         var in = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
 
         FileOutputStream fos = new FileOutputStream("my.ciphertext");
 
         new TDF().createTDF(in, fos, tdfConfig,
-                        sdk.getServices().kas(),
-                        sdk.getServices().attributes());
+                sdk.getServices().kas(),
+                sdk.getServices().attributes());
     }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
@@ -7,10 +7,8 @@ import io.opentdf.platform.sdk.nanotdf.NanoTDFType;
 import io.opentdf.platform.sdk.nanotdf.SymmetricAndPayloadConfig;
 
 import io.opentdf.platform.policy.Value;
-import org.bouncycastle.oer.its.ieee1609dot2.HeaderInfo;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
@@ -99,12 +97,14 @@ public class Config {
         // Optional Map of Assertion Verification Keys
         AssertionVerificationKeys assertionVerificationKeys = new AssertionVerificationKeys();
         boolean disableAssertionVerification;
+        KeyType sessionKeyType;;
     }
 
     @SafeVarargs
     public static TDFReaderConfig newTDFReaderConfig(Consumer<TDFReaderConfig>... options) {
         TDFReaderConfig config = new TDFReaderConfig();
         config.disableAssertionVerification = false;
+        config.sessionKeyType = KeyType.RSA2048Key;
         for (Consumer<TDFReaderConfig> option : options) {
             option.accept(config);
         }
@@ -120,6 +120,9 @@ public class Config {
         return (TDFReaderConfig config) -> config.disableAssertionVerification = disable;
     }
 
+    public static Consumer<TDFReaderConfig> WithSessionKeyType(KeyType keyType) {
+        return (TDFReaderConfig config) -> config.sessionKeyType = keyType;
+    }
     public static class TDFConfig {
         public Boolean autoconfigure;
         public int defaultSegmentSize;
@@ -136,6 +139,7 @@ public class Config {
         public List<io.opentdf.platform.sdk.AssertionConfig> assertionConfigList;
         public String mimeType;
         public List<Autoconfigure.KeySplitStep> splitPlan;
+        public KeyType wrappingKeyType;
 
         public TDFConfig() {
             this.autoconfigure = true;
@@ -149,6 +153,7 @@ public class Config {
             this.assertionConfigList = new ArrayList<>();
             this.mimeType = DEFAULT_MIME_TYPE;
             this.splitPlan = new ArrayList<>();
+            this.wrappingKeyType = KeyType.RSA2048Key;
         }
     }
 
@@ -244,6 +249,10 @@ public class Config {
             config.autoconfigure = enable;
             config.splitPlan = null;
         };
+    }
+
+    public static Consumer<TDFConfig> WithWrappingKeyAlg(KeyType    keyType) {
+        return (TDFConfig config) -> config.wrappingKeyType = keyType;
     }
 
     // public static Consumer<TDFConfig> withDisableEncryption() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Config.java
@@ -97,7 +97,7 @@ public class Config {
         // Optional Map of Assertion Verification Keys
         AssertionVerificationKeys assertionVerificationKeys = new AssertionVerificationKeys();
         boolean disableAssertionVerification;
-        KeyType sessionKeyType;;
+        KeyType sessionKeyType;
     }
 
     @SafeVarargs

--- a/sdk/src/main/java/io/opentdf/platform/sdk/CryptoUtils.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/CryptoUtils.java
@@ -3,6 +3,7 @@ package io.opentdf.platform.sdk;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.*;
+import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
 
 /**
@@ -37,6 +38,30 @@ public class CryptoUtils {
         }
         kpg.initialize(KEYPAIR_SIZE);
         return kpg.generateKeyPair();
+    }
+
+    public static KeyPair generateECKeypair(String curveName) {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("EC");
+            ECGenParameterSpec ecSpec = new ECGenParameterSpec(curveName);
+            kpg.initialize(ecSpec);
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+            throw new SDKException("error creating EC keypair", e);
+        }
+        return kpg.generateKeyPair();
+    }
+
+    public static String getPublicKeyPEM(PublicKey publicKey) {
+        return "-----BEGIN PUBLIC KEY-----\r\n" +
+                Base64.getMimeEncoder().encodeToString(publicKey.getEncoded()) +
+                "\r\n-----END PUBLIC KEY-----";
+    }
+
+    public  static String getPrivateKeyPEM(PrivateKey privateKey) {
+        return "-----BEGIN PRIVATE KEY-----\r\n" +
+                Base64.getMimeEncoder().encodeToString(privateKey.getEncoded()) +
+                "\r\n-----END PRIVATE KEY-----";
     }
 
     public static String getRSAPublicKeyPEM(PublicKey publicKey) {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -17,7 +17,6 @@ import io.opentdf.platform.kas.PublicKeyResponse;
 import io.opentdf.platform.kas.RewrapRequest;
 import io.opentdf.platform.kas.RewrapResponse;
 import io.opentdf.platform.sdk.Config.KASInfo;
-import io.opentdf.platform.sdk.nanotdf.CryptoKeyPair;
 import io.opentdf.platform.sdk.nanotdf.ECKeyPair;
 import io.opentdf.platform.sdk.nanotdf.NanoTDFType;
 import io.opentdf.platform.sdk.TDF.KasBadRequestException;
@@ -48,8 +47,7 @@ public class KASClient implements SDK.KAS {
     private final RSASSASigner signer;
     private final AsymDecryption decryptor;
     private final String publicKeyPEM;
-    private CryptoKeyPair keyPair;
-    private KASKeyCache kasKeyCache;
+       private KASKeyCache kasKeyCache;
 
     /***
      * A client that communicates with KAS

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -47,7 +47,7 @@ public class KASClient implements SDK.KAS {
     private final RSASSASigner signer;
     private final AsymDecryption decryptor;
     private final String publicKeyPEM;
-       private KASKeyCache kasKeyCache;
+    private KASKeyCache kasKeyCache;
 
     /***
      * A client that communicates with KAS
@@ -87,9 +87,13 @@ public class KASClient implements SDK.KAS {
         if (cachedValue != null) {
             return cachedValue;
         }
-        var resp = getStub(kasInfo.URL)
-                .publicKey(
-                        PublicKeyRequest.newBuilder().setAlgorithm(kasInfo.Algorithm).build());
+
+        PublicKeyRequest request = (kasInfo.Algorithm == null || kasInfo.Algorithm.isEmpty())
+                ? PublicKeyRequest.getDefaultInstance()
+                : PublicKeyRequest.newBuilder().setAlgorithm(kasInfo.Algorithm).build();
+
+        PublicKeyResponse resp = getStub(kasInfo.URL).publicKey(request);
+
         var kiCopy = new Config.KASInfo();
         kiCopy.KID = resp.getKid();
         kiCopy.PublicKey = resp.getPublicKey();

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
@@ -38,4 +38,8 @@ public enum KeyType {
         }
         throw new IllegalArgumentException("No enum constant for key type: " + keyType);
     }
+
+    public boolean isEc() {
+        return this != RSA2048Key;
+    }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
@@ -1,0 +1,41 @@
+package io.opentdf.platform.sdk;
+
+public enum KeyType {
+    RSA2048Key("rsa:2048"),
+    EC256Key("ec:secp256r1"),
+    EC384Key("ec:secp384r1"),
+    EC521Key("ec:secp521r1");
+
+    private final String keyType;
+
+    KeyType(String keyType) {
+        this.keyType = keyType;
+    }
+
+    @Override
+    public String toString() {
+        return keyType;
+    }
+
+    public String getCurveName() {
+        switch (this) {
+            case EC256Key:
+                return "secp256r1";
+            case EC384Key:
+                return "secp384r1";
+            case EC521Key:
+                return "secp521r1";
+            default:
+                throw new IllegalArgumentException("Unsupported key type: " + this);
+        }
+    }
+
+    public static KeyType fromString(String keyType) {
+        for (KeyType type : KeyType.values()) {
+            if (type.keyType.equalsIgnoreCase(keyType)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("No enum constant for key type: " + keyType);
+    }
+}

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
@@ -197,25 +197,25 @@ public class Manifest {
         public String kid;
         public String sid;
         public String schemaVersion;
+        public String ephemeralPublicKey;
 
         @Override
         public boolean equals(Object o) {
-            if (this == o)
-                return true;
-            if (o == null || getClass() != o.getClass())
-                return false;
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
             KeyAccess keyAccess = (KeyAccess) o;
             return Objects.equals(keyType, keyAccess.keyType) && Objects.equals(url, keyAccess.url)
                     && Objects.equals(protocol, keyAccess.protocol) && Objects.equals(wrappedKey, keyAccess.wrappedKey)
                     && Objects.equals(policyBinding, keyAccess.policyBinding)
                     && Objects.equals(encryptedMetadata, keyAccess.encryptedMetadata)
                     && Objects.equals(kid, keyAccess.kid)
-                    && Objects.equals(schemaVersion, keyAccess.schemaVersion);
+                    && Objects.equals(schemaVersion, keyAccess.schemaVersion)
+                    && Objects.equals(ephemeralPublicKey, keyAccess.ephemeralPublicKey);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(keyType, url, protocol, wrappedKey, policyBinding, encryptedMetadata, kid, schemaVersion);
+            return Objects.hash(keyType, url, protocol, wrappedKey, policyBinding, encryptedMetadata, kid, schemaVersion, ephemeralPublicKey);
         }
     }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
@@ -53,7 +53,8 @@ public class SDK implements AutoCloseable {
 
         Config.KASInfo getECPublicKey(Config.KASInfo kasInfo, NanoTDFType.ECCurve curve);
 
-        byte[] unwrap(Manifest.KeyAccess keyAccess, String policy,  KeyType sessionKeyType);
+        byte[] unwrap(Manifest.KeyAccess keyAccess, String policy,
+                      KeyType sessionKeyType);
 
         byte[] unwrapNanoTDF(NanoTDFType.ECCurve curve, String header, String kasURL);
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
@@ -53,7 +53,7 @@ public class SDK implements AutoCloseable {
 
         Config.KASInfo getECPublicKey(Config.KASInfo kasInfo, NanoTDFType.ECCurve curve);
 
-        byte[] unwrap(Manifest.KeyAccess keyAccess, String policy);
+        byte[] unwrap(Manifest.KeyAccess keyAccess, String policy,  KeyType sessionKeyType);
 
         byte[] unwrapNanoTDF(NanoTDFType.ECCurve curve, String header, String kasURL);
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -627,7 +627,7 @@ public class TDF {
 
     public Reader loadTDF(SeekableByteChannel tdf, SDK.KAS kas)
             throws DecoderException, IOException, ParseException, NoSuchAlgorithmException, JOSEException {
-        return loadTDF(tdf, kas, new Config.TDFReaderConfig());
+        return loadTDF(tdf, kas, Config.newTDFReaderConfig());
     }
 
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -330,8 +330,8 @@ public class TDF {
             keyAccess.sid = splitID;
             keyAccess.schemaVersion = KEY_ACCESS_SECHMA_VERSION;
 
-            if (tdfConfig.wrappingKeyType != KeyType.RSA2048Key) {
-                var ecKeyWrappedKeyInfo =createECWrappedKey(tdfConfig, kasInfo, symKey);
+            if (tdfConfig.wrappingKeyType.isEc()) {
+                var ecKeyWrappedKeyInfo = createECWrappedKey(tdfConfig, kasInfo, symKey);
                 keyAccess.wrappedKey = ecKeyWrappedKeyInfo.wrappedKey;
                 keyAccess.ephemeralPublicKey = ecKeyWrappedKeyInfo.publicKey;
                 keyAccess.keyType = kECWrapped;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ECKeyPair.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ECKeyPair.java
@@ -41,20 +41,26 @@ public class ECKeyPair {
     private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
 
     public enum NanoTDFECCurve {
-        SECP256R1("secp256r1"),
-        PRIME256V1("prime256v1"),
-        SECP384R1("secp384r1"),
-        SECP521R1("secp521r1");
+        SECP256R1("secp256r1", KeyType.EC256Key),
+        PRIME256V1("prime256v1", KeyType.EC256Key),
+        SECP384R1("secp384r1", KeyType.EC384Key),
+        SECP521R1("secp521r1", KeyType.EC521Key);
 
         private String name;
+        private KeyType keyType;
 
-        NanoTDFECCurve(String curveName) {
+        NanoTDFECCurve(String curveName, KeyType keyType) {
             this.name = curveName;
+            this.keyType = keyType;
         }
 
         @Override
         public String toString() {
             return name;
+        }
+
+        public KeyType getKeyType() {
+            return keyType;
         }
     }
 
@@ -144,17 +150,6 @@ public class ECKeyPair {
         }
 
         return writer.toString();
-    }
-
-    public KeyType getKeyType() {
-        if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP256R1.toString())) {
-            return KeyType.EC256Key;
-        } else if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP384R1.toString())) {
-            return KeyType.EC384Key;
-        } else if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP521R1.toString())) {
-            return KeyType.EC521Key;
-        }
-        return null;
     }
 
     public int keySize() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ECKeyPair.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/nanotdf/ECKeyPair.java
@@ -1,5 +1,6 @@
 package io.opentdf.platform.sdk.nanotdf;
 
+import io.opentdf.platform.sdk.KeyType;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -143,6 +144,17 @@ public class ECKeyPair {
         }
 
         return writer.toString();
+    }
+
+    public KeyType getKeyType() {
+        if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP256R1.toString())) {
+            return KeyType.EC256Key;
+        } else if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP384R1.toString())) {
+            return KeyType.EC384Key;
+        } else if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP521R1.toString())) {
+            return KeyType.EC521Key;
+        }
+        return null;
     }
 
     public int keySize() {

--- a/sdk/src/test/java/io/opentdf/platform/sdk/KASClientTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/KASClientTest.java
@@ -165,7 +165,7 @@ public class KASClientTest {
                 var serverWrappedKey = new AsymEncryption(serverKeypair.getPublic()).encrypt(plaintextKey);
                 keyAccess.wrappedKey = Base64.getEncoder().encodeToString(serverWrappedKey);
 
-                rewrapResponse = kas.unwrap(keyAccess, "the policy");
+                rewrapResponse = kas.unwrap(keyAccess, "the policy", KeyType.RSA2048Key);
             }
             assertThat(rewrapResponse).containsExactly(plaintextKey);
         } finally {

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
@@ -61,7 +61,7 @@ public class NanoTDFTest {
         }
 
         @Override
-        public byte[] unwrap(Manifest.KeyAccess keyAccess, String policy) {
+        public byte[] unwrap(Manifest.KeyAccess keyAccess, String policy, KeyType sessionKeyType) {
             int index = Integer.parseInt(keyAccess.url);
             var decryptor = new AsymDecryption(keypairs.get(index).getPrivate());
             var bytes = Base64.getDecoder().decode(keyAccess.wrappedKey);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/SDKBuilderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/SDKBuilderTest.java
@@ -300,7 +300,7 @@ public class SDKBuilderTest {
             keyAccess.url = "localhost:" + kasServer.getPort();
 
             try {
-                services.kas().unwrap(keyAccess, "");
+                services.kas().unwrap(keyAccess, "", KeyType.RSA2048Key);
             } catch (Exception ignoredException) {
                 // not going to bother making a real request with real crypto, just make sure
                 // that

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFE2ETest.java
@@ -10,10 +10,21 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class TDFE2ETest {
+
+    public class TDFConfigPair {
+        public Config.TDFConfig tdfConfig;
+        public Config.TDFReaderConfig tdfReaderConfig;
+
+        public TDFConfigPair(Config.TDFConfig tdfConfig, Config.TDFReaderConfig tdfReaderConfig) {
+            this.tdfConfig = tdfConfig;
+            this.tdfReaderConfig = tdfReaderConfig;
+        }
+    }
 
     @Test @Disabled("this needs the backend services running to work")
     public void createAndDecryptTdfIT() throws Exception {
@@ -25,23 +36,34 @@ public class TDFE2ETest {
                 .buildServices()
                 .services;
 
-
         var kasInfo = new Config.KASInfo();
         kasInfo.URL = "localhost:8080";
-        Config.TDFConfig config = Config.newTDFConfig(Config.withKasInformation(kasInfo));
 
-        String plainText = "text";
-        InputStream plainTextInputStream = new ByteArrayInputStream(plainText.getBytes());
-        ByteArrayOutputStream tdfOutputStream = new ByteArrayOutputStream();
+        List<TDFConfigPair> tdfConfigPairs = List.of(
+                new TDFConfigPair(
+                        Config.newTDFConfig(Config.withKasInformation(kasInfo)),
+                        Config.newTDFReaderConfig()
+                ),
+                new TDFConfigPair(
+                        Config.newTDFConfig(Config.withKasInformation(kasInfo), Config.WithWrappingKeyAlg(KeyType.EC256Key)),
+                        Config.newTDFReaderConfig(Config.WithSessionKeyType(KeyType.EC256Key))
+                )
+        );
 
-        TDF tdf = new TDF();
-        tdf.createTDF(plainTextInputStream, tdfOutputStream, config, sdk.kas(), sdk.attributes());
+        for (TDFConfigPair configPair : tdfConfigPairs) {
+            String plainText = "text";
+            InputStream plainTextInputStream = new ByteArrayInputStream(plainText.getBytes());
+            ByteArrayOutputStream tdfOutputStream = new ByteArrayOutputStream();
 
-        var unwrappedData = new java.io.ByteArrayOutputStream();
-        var reader = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()),  sdk.kas());
-        reader.readPayload(unwrappedData);
+            TDF tdf = new TDF();
+            tdf.createTDF(plainTextInputStream, tdfOutputStream, configPair.tdfConfig, sdk.kas(), sdk.attributes());
 
-        assertThat(unwrappedData.toString(StandardCharsets.UTF_8)).isEqualTo("text");
+            var unwrappedData = new java.io.ByteArrayOutputStream();
+            var reader = tdf.loadTDF(new SeekableInMemoryByteChannel(tdfOutputStream.toByteArray()), sdk.kas(), configPair.tdfReaderConfig);
+            reader.readPayload(unwrappedData);
+
+            assertThat(unwrappedData.toString(StandardCharsets.UTF_8)).isEqualTo("text");
+        }
     }
 
     @Test @Disabled("this needs the backend services running to work")

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -52,7 +52,7 @@ public class TDFTest {
             try {
                 int index = Integer.parseInt(keyAccess.url);
                 var bytes = Base64.getDecoder().decode(keyAccess.wrappedKey);
-                if (sessionKeyType != KeyType.RSA2048Key) {
+                if (sessionKeyType.isEc()) {
                     var  kasPrivateKey = CryptoUtils.getPrivateKeyPEM(keypairs.get(index).getPrivate());
                     var privateKey = ECKeyPair.privateKeyFromPem(kasPrivateKey);
                     var clientEphemeralPublicKey = keyAccess.ephemeralPublicKey;

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -93,7 +93,7 @@ public class TDFTest {
 
     @BeforeAll
     static void createKeypairs() {
-        for (int i = 0; i < 1 + new Random().nextInt(5); i++) {
+        for (int i = 0; i < 2 + new Random().nextInt(5); i++) {
             if (i % 2 == 0) {
                 keypairs.add(CryptoUtils.generateRSAKeypair());
             } else {


### PR DESCRIPTION
### Proposed Changes

- Adds a new `ec-wrapped` KAO type that uses a hybrid EC encryption scheme to wrap the values
- To use with SDK, adds a new `WithWrappingKeyAlg` and `WithSessionKeyType` functional option

### Checklist

- [ ] I have added or updated unit tests