### PR TITLE
chore(sdk): Pins protocol buffer sources to tags

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -334,7 +334,7 @@ jobs:
       contents: read
       packages: read
     needs: platform-integration
-    uses: opentdf/tests/.github/workflows/xtest.yml@main
+    uses: opentdf/tests/.github/workflows/xtest.yml@DSPX-959-java-sdk-protogen-changes
     with:
       focus-sdk: java
       java-ref: ${{ github.ref }} latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Conventional Commits Check
         if: contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name)
         id: conventional-commits
-        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -58,12 +58,12 @@ jobs:
   mavenverify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK
-        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: "11"
           distribution: "adopt"
@@ -79,26 +79,26 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK
-        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: "17"
           distribution: "temurin"
           server-id: github
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -115,12 +115,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Java SDK
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK
-        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: "11"
           distribution: "adopt"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Buf setup
-      uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3
+      uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
 
     - name: Initialize the CodeQL tools for scanning
       uses: github/codeql-action/init@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           app-id: "${{ secrets.APP_ID }}"
           private-key: "${{ secrets.AUTOMATION_KEY }}"
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           token: "${{ steps.generate_token.outputs.token }}"
           config-file: release-please.json
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Buf
-        uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       # stage maven profile
       - name: Set up JDK to publish to GitHub Packages
         if: github.ref == 'refs/heads/main'
-        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: "11"
           distribution: "adopt"
@@ -60,7 +60,7 @@ jobs:
       # release maven profile
       - name: Set up JDK to publish to Maven Central
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: "11"
           distribution: "adopt"

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -1,0 +1,65 @@
+name: "Update Platform Branch"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The new tag or branch to update the platform.branch property to ."
+        required: true
+        default: "protocol/go/v0.2.29"
+
+jobs:
+  update-platform-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout java-sdk repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate tag as a valid git ref
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if ! [[ "$TAG" =~ ^[a-zA-Z0-9._\-/]+$ ]]; then
+            echo "Invalid tag format: [$TAG]"
+            exit 1
+          fi
+
+      - name: Check if tag exists in the repository
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if ! git ls-remote --exit-code --heads --tags https://github.com/opentdf/platform.git "$TAG"; then
+            echo "Tag or branch [$TAG] does not exist in the platform repository."
+            exit 1
+          fi
+
+      - name: Update platform.branch in pom.xml files
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${TAG}</platform.branch>|g" {} \;
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b update-platform-branch
+          git add .
+          git commit -m "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+
+      - name: Push changes
+        run: |
+          git push origin update-platform-branch
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+          branch: update-platform-branch
+          title: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+          body: "This PR updates the platform.branch property in all pom.xml files to the new tag or branch: ${{ github.event.inputs.tag }}."
+          labels: "automated-update"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -17,6 +17,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>11</maven.compiler.release>
+    <platform.branch>protocol/go/v0.2.28</platform.branch>
   </properties>
 
   <dependencyManagement>
@@ -138,7 +139,7 @@
                           <!-- Generate OpenTDF Platform Protobuf -->
                           <exec executable="buf" dir="." failOnError="true">
                               <arg value="generate"/>
-                              <arg value="https://github.com/opentdf/platform.git#branch=main,subdir=service"/>
+                              <arg value="https://github.com/opentdf/platform.git#branch=${platform.branch},subdir=service"/>
                               <arg value="-o"/>
                               <arg value="target/generated-sources"/>
                           </exec>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <jazzer.version>0.22.1</jazzer.version>
         <jazzer.baseurl>https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v${jazzer.version}</jazzer.baseurl>
+        <platform.branch>protocol/go/v0.2.28</platform.branch>
     </properties>
     <dependencies>
         <!-- Logging Dependencies -->
@@ -257,7 +258,7 @@
                                 <!-- Generate OpenTDF Platform Protobuf -->
                                 <exec executable="buf" dir="." failOnError="true">
                                     <arg value="generate"/>
-                                    <arg value="https://github.com/opentdf/platform.git#branch=main,subdir=service"/>
+                                    <arg value="https://github.com/opentdf/platform.git#branch=${platform.branch},subdir=service"/>
                                     <arg value="-o"/>
                                     <arg value="target/generated-sources"/>
                                 </exec>


### PR DESCRIPTION
- Includes dispatchable workflow to generate PRs that bump this, to be used from the source repo (platform)
- Should these be shas instead of tags?