### PR TITLE
chore(ci): Adds workflow to bump protocol buffers

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -334,7 +334,7 @@ jobs:
       contents: read
       packages: read
     needs: platform-integration
-    uses: opentdf/tests/.github/workflows/xtest.yml@DSPX-959-java-sdk-protogen-changes
+    uses: opentdf/tests/.github/workflows/xtest.yml@main
     with:
       focus-sdk: java
       java-ref: ${{ github.ref }} latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -334,7 +334,7 @@ jobs:
       contents: read
       packages: read
     needs: platform-integration
-    uses: opentdf/tests/.github/workflows/xtest.yml@main
+    uses: opentdf/tests/.github/workflows/xtest.yml@DSPX-959-java-sdk-protogen-changes
     with:
       focus-sdk: java
       java-ref: ${{ github.ref }} latest

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -1,0 +1,65 @@
+name: "Update Platform Branch"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The new tag or branch to update the platform.branch property to ."
+        required: true
+        default: "protocol/go/v0.2.29"
+
+jobs:
+  update-platform-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout java-sdk repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate tag as a valid git ref
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if ! [[ "$TAG" =~ ^[a-zA-Z0-9._\-/]+$ ]]; then
+            echo "Invalid tag format: [$TAG]"
+            exit 1
+          fi
+
+      - name: Check if tag exists in the repository
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if ! git ls-remote --exit-code --heads --tags https://github.com/opentdf/platform.git "$TAG"; then
+            echo "Tag or branch [$TAG] does not exist in the platform repository."
+            exit 1
+          fi
+
+      - name: Update platform.branch in pom.xml files
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${TAG}</platform.branch>|g" {} \;
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b update-platform-branch
+          git add .
+          git commit -m "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+
+      - name: Push changes
+        run: |
+          git push origin update-platform-branch
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+          branch: update-platform-branch
+          title: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+          body: "This PR updates the platform.branch property in all pom.xml files to the new tag or branch: ${{ github.event.inputs.tag }}."
+          labels: "automated-update"

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -7,6 +7,8 @@ name: "Update Platform Branch"
 #   `act workflow_dispatch -W ./.github/workflows/update-platform-branch.yaml --input tag=protocol/go/v0.3.1`
 
 on:
+  schedule:
+    - cron: "0 0 * * *" # Runs daily at midnight UTC
   workflow_call:
     inputs:
       tag:
@@ -29,75 +31,89 @@ jobs:
 
     steps:
       - name: Checkout java-sdk repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v3
         with:
-          persist-credentials: true # Required for "commit changes" and push steps below
+          persist-credentials: true
 
-      - name: Validate tag as a valid git ref
+      - name: Fetch latest semver tag for protocol/go
+        id: fetch-latest-tag
         run: |
-          if ! echo "$TAG" | grep -Eq "^[a-zA-Z0-9._\-\/]+$"; then
-            echo "Invalid tag format: [$TAG]"
+          if [ -z "${{ github.event.inputs.tag }}" ]; then
+            LATEST_TAG=$(git ls-remote --tags https://github.com/opentdf/platform.git | \
+              grep "refs/tags/protocol/go" | \
+              sed 's|.*/||' | \
+              sort -V | \
+              tail -n1)
+            echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          else
+            echo "LATEST_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          fi
+
+      - name: Check if update is needed
+        id: check-update
+        run: |
+          CURRENT_TAG=$(grep -oP '<platform.branch>\K.*(?=</platform.branch>)' pom.xml | head -n1)
+          if [ "$CURRENT_TAG" = "$LATEST_TAG" ]; then
+            echo "Platform branch is already up-to-date."
             exit 1
           fi
-          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_ENV
+
+      - name: Check for existing PR
+        id: check-pr
+        run: |
+          EXISTING_PR=$(gh pr list --head update-platform-branch --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "EXISTING_PR=$EXISTING_PR" >> $GITHUB_ENV
+          fi
         env:
-          TAG: ${{ github.event.inputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check if tag exists in the repository
+      - name: Check out existing PR
+        if: steps.check-pr.outputs.EXISTING_PR != ''
         run: |
-          if ! git ls-remote --exit-code --heads --tags https://github.com/opentdf/platform.git "$TAG"; then
-            echo "Tag or branch [$TAG] does not exist in the platform repository."
-            exit 1
-          fi
+          git fetch origin update-platform-branch:update-platform-branch
+          git checkout update-platform-branch
 
       - name: Update platform.branch in pom.xml files
         run: |
-            find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${TAG}</platform.branch>|g" {} \;
-            CHANGED_FILES=$(find . -name "pom.xml" -exec diff -u {} {}.bak \;)
-            if [ -z "$CHANGED_FILES" ]; then
-              echo "No changes detected in pom.xml files." | tee -a $GITHUB_STEP_SUMMARY
-              find . -name "pom.xml.bak" -delete
-              exit 1
-            fi
-            echo "The following pom.xml files were updated: $CHANGED_FILES"
+          find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${LATEST_TAG}</platform.branch>|g" {} \;
+          CHANGED_FILES=$(find . -name "pom.xml" -exec diff -u {} {}.bak \;)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No changes detected in pom.xml files." | tee -a $GITHUB_STEP_SUMMARY
             find . -name "pom.xml.bak" -delete
-
-      - name: Fetch release notes for the tag
-        id: fetch-release-notes
-        run: |
-          RELEASE_URL="https://api.github.com/repos/opentdf/platform/releases/tags/$TAG"
-          RESPONSE=$(curl -s -H "Accept: application/vnd.github.v3+json" "$RELEASE_URL")
-          RELEASE_NOTES=$(echo "$RESPONSE" | jq -r '.body // ""')
-          if [ "$RELEASE_NOTES" = "" ]; then
-            echo "No release notes found for tag $TAG."
+            exit 1
           fi
-          echo "RELEASE_NOTES=$RELEASE_NOTES" >> $GITHUB_ENV
-          echo "RELEASE_URL=https://github.com/opentdf/platform/releases/tag/$TAG" >> $GITHUB_ENV
+          echo "The following pom.xml files were updated: $CHANGED_FILES"
+          find . -name "pom.xml.bak" -delete
 
-      - name: Commit changes
+      - name: Create new branch
+        if: steps.check-pr.outputs.EXISTING_PR == ''
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b update-platform-branch
           git add .
-          if [ -n "$RELEASE_NOTES" ]; then
-            git commit -m "fix(sdk): Updates to proto version $TAG\n\nRelease Notes:\n$RELEASE_NOTES\n\nSee the release: $RELEASE_URL"
-          else
-            git commit -m "fix(sdk): Updates to proto version $TAG\n\nSee the release: $RELEASE_URL"
-          fi
+          git commit -m "fix(sdk): Updates to proto version $LATEST_TAG"
           git push origin update-platform-branch
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+      - name: Update existing PR
+        if: steps.check-pr.outputs.EXISTING_PR != ''
+        run: |
+          git add .
+          git commit --amend --no-edit
+          git push origin update-platform-branch --force
+
+      - name: Create New PR
+        if: steps.check-pr.outputs.EXISTING_PR == ''
+        uses: peter-evans/create-pull-request@v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+          commit-message: "fix(sdk): Updates to proto version $LATEST_TAG"
           branch: update-platform-branch
-          title: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+          title: "fix(sdk): Updates to proto version $LATEST_TAG"
           body: |
-            This PR updates the platform.branch property in all pom.xml files to the new tag or branch: ${{ github.event.inputs.tag }}.
+            This PR updates the platform.branch property in all pom.xml files to the new tag or branch: $LATEST_TAG.
 
-            See the release: $RELEASE_URL
+            See the release: https://github.com/opentdf/platform/releases/tag/$LATEST_TAG
 
             Release Notes:
             $RELEASE_NOTES

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout java-sdk repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: true # Required for "commit changes" and push steps below
 
       - name: Validate tag as a valid git ref
         run: |
@@ -48,13 +50,32 @@ jobs:
           TAG="${{ github.event.inputs.tag }}"
           find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${TAG}</platform.branch>|g" {} \;
 
+      - name: Fetch release notes for the tag
+        id: fetch-release-notes
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          RELEASE_URL="https://api.github.com/repos/opentdf/platform/releases/tags/$TAG"
+          RESPONSE=$(curl -s -H "Accept: application/vnd.github.v3+json" "$RELEASE_URL")
+          RELEASE_NOTES=$(echo "$RESPONSE" | jq -r '.body // ""')
+          if [ "$RELEASE_NOTES" = "" ]; then
+            echo "No release notes found for tag $TAG."
+          fi
+          echo "::set-output name=release_notes::$RELEASE_NOTES"
+          echo "::set-output name=release_url::https://github.com/opentdf/platform/releases/tag/$TAG"
+
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b update-platform-branch
           git add .
-          git commit -m "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
+          RELEASE_NOTES="${{ steps.fetch-release-notes.outputs.release_notes }}"
+          RELEASE_URL="${{ steps.fetch-release-notes.outputs.release_url }}"
+          if [ -n "$RELEASE_NOTES" ]; then
+            git commit -m "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}\n\nRelease Notes:\n$RELEASE_NOTES\n\nSee the release: $RELEASE_URL"
+          else
+            git commit -m "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}\n\nSee the release: $RELEASE_URL"
+          fi
 
       - name: Push changes
         run: |
@@ -67,5 +88,11 @@ jobs:
           commit-message: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
           branch: update-platform-branch
           title: "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}"
-          body: "This PR updates the platform.branch property in all pom.xml files to the new tag or branch: ${{ github.event.inputs.tag }}."
+          body: |
+            This PR updates the platform.branch property in all pom.xml files to the new tag or branch: ${{ github.event.inputs.tag }}.
+
+            See the release: ${{ steps.fetch-release-notes.outputs.release_url }}
+
+            Release Notes:
+            ${{ steps.fetch-release-notes.outputs.release_notes }}
           labels: "automated-update"

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -74,7 +74,7 @@ jobs:
           echo "RELEASE_NOTES=$RELEASE_NOTES" >> $GITHUB_ENV
           echo "RELEASE_URL=https://github.com/opentdf/platform/releases/tag/$TAG" >> $GITHUB_ENV
 
-      - name: Commit and changes
+      - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -53,12 +53,13 @@ jobs:
       - name: Update platform.branch in pom.xml files
         run: |
             find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${TAG}</platform.branch>|g" {} \;
-            CHANGED_FILES=$(find . -name "pom.xml.bak" -exec diff -u {} $(echo {} | sed 's/.bak$//') \;)
+            CHANGED_FILES=$(find . -name "pom.xml" -exec diff -u {} {}.bak \;)
             if [ -z "$CHANGED_FILES" ]; then
               echo "No changes detected in pom.xml files." | tee -a $GITHUB_STEP_SUMMARY
               find . -name "pom.xml.bak" -delete
               exit 1
             fi
+            echo "The following pom.xml files were updated: $CHANGED_FILES"
             find . -name "pom.xml.bak" -delete
 
       - name: Fetch release notes for the tag

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -44,9 +44,9 @@ jobs:
               sed 's|.*/||' | \
               sort -V | \
               tail -n1)
-            echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+            echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_ENV"
           else
-            echo "LATEST_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+            echo "LATEST_TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
           fi
 
       - name: Check if update is needed
@@ -57,14 +57,14 @@ jobs:
             echo "Platform branch is already up-to-date."
             exit 1
           fi
-          echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_ENV
+          echo "CURRENT_TAG=$CURRENT_TAG" >> "$GITHUB_ENV"
 
       - name: Check for existing PR
         id: check-pr
         run: |
           EXISTING_PR=$(gh pr list --head update-platform-branch --json number --jq '.[0].number')
           if [ -n "$EXISTING_PR" ]; then
-            echo "EXISTING_PR=$EXISTING_PR" >> $GITHUB_ENV
+            echo "EXISTING_PR=$EXISTING_PR" >> "$GITHUB_OUTPUT"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -22,6 +22,10 @@ on:
 jobs:
   update-platform-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
 
     steps:
       - name: Checkout java-sdk repository
@@ -31,15 +35,16 @@ jobs:
 
       - name: Validate tag as a valid git ref
         run: |
-          TAG="${{ github.event.inputs.tag }}"
           if ! echo "$TAG" | grep -Eq "^[a-zA-Z0-9._\-\/]+$"; then
             echo "Invalid tag format: [$TAG]"
             exit 1
           fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
+        env:
+          TAG: ${{ github.event.inputs.tag }}
 
       - name: Check if tag exists in the repository
         run: |
-          TAG="${{ github.event.inputs.tag }}"
           if ! git ls-remote --exit-code --heads --tags https://github.com/opentdf/platform.git "$TAG"; then
             echo "Tag or branch [$TAG] does not exist in the platform repository."
             exit 1
@@ -47,38 +52,38 @@ jobs:
 
       - name: Update platform.branch in pom.xml files
         run: |
-          TAG="${{ github.event.inputs.tag }}"
-          find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${TAG}</platform.branch>|g" {} \;
+            find . -name "pom.xml" -exec sed -i.bak "s|<platform.branch>.*</platform.branch>|<platform.branch>${TAG}</platform.branch>|g" {} \;
+            CHANGED_FILES=$(find . -name "pom.xml.bak" -exec diff -u {} $(echo {} | sed 's/.bak$//') \;)
+            if [ -z "$CHANGED_FILES" ]; then
+              echo "No changes detected in pom.xml files." | tee -a $GITHUB_STEP_SUMMARY
+              find . -name "pom.xml.bak" -delete
+              exit 1
+            fi
+            find . -name "pom.xml.bak" -delete
 
       - name: Fetch release notes for the tag
         id: fetch-release-notes
         run: |
-          TAG="${{ github.event.inputs.tag }}"
           RELEASE_URL="https://api.github.com/repos/opentdf/platform/releases/tags/$TAG"
           RESPONSE=$(curl -s -H "Accept: application/vnd.github.v3+json" "$RELEASE_URL")
           RELEASE_NOTES=$(echo "$RESPONSE" | jq -r '.body // ""')
           if [ "$RELEASE_NOTES" = "" ]; then
             echo "No release notes found for tag $TAG."
           fi
-          echo "::set-output name=release_notes::$RELEASE_NOTES"
-          echo "::set-output name=release_url::https://github.com/opentdf/platform/releases/tag/$TAG"
+          echo "RELEASE_NOTES=$RELEASE_NOTES" >> $GITHUB_ENV
+          echo "RELEASE_URL=https://github.com/opentdf/platform/releases/tag/$TAG" >> $GITHUB_ENV
 
-      - name: Commit changes
+      - name: Commit and changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b update-platform-branch
           git add .
-          RELEASE_NOTES="${{ steps.fetch-release-notes.outputs.release_notes }}"
-          RELEASE_URL="${{ steps.fetch-release-notes.outputs.release_url }}"
           if [ -n "$RELEASE_NOTES" ]; then
-            git commit -m "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}\n\nRelease Notes:\n$RELEASE_NOTES\n\nSee the release: $RELEASE_URL"
+            git commit -m "fix(sdk): Updates to proto version $TAG\n\nRelease Notes:\n$RELEASE_NOTES\n\nSee the release: $RELEASE_URL"
           else
-            git commit -m "fix(sdk): Updates to proto version ${{ github.event.inputs.tag }}\n\nSee the release: $RELEASE_URL"
+            git commit -m "fix(sdk): Updates to proto version $TAG\n\nSee the release: $RELEASE_URL"
           fi
-
-      - name: Push changes
-        run: |
           git push origin update-platform-branch
 
       - name: Create Pull Request
@@ -91,8 +96,8 @@ jobs:
           body: |
             This PR updates the platform.branch property in all pom.xml files to the new tag or branch: ${{ github.event.inputs.tag }}.
 
-            See the release: ${{ steps.fetch-release-notes.outputs.release_url }}
+            See the release: $RELEASE_URL
 
             Release Notes:
-            ${{ steps.fetch-release-notes.outputs.release_notes }}
+            $RELEASE_NOTES
           labels: "automated-update"

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -1,4 +1,7 @@
 name: "Update Platform Branch"
+# This workflow updates the platform.branch property in all pom.xml files to a new tag or branch.
+# It is triggered by a manual dispatch or by a call from another workflow - notably from platform changes to protocol/go.
+# This property is used to select which versions of the protocol buffer definitions to use.
 
 on:
   workflow_call:
@@ -9,9 +12,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "The new tag or branch to update the platform.branch property to ."
+        description: "The new tag or branch to update the platform.branch property to use for targeting the RPC protocol buffers."
         required: true
-        default: "protocol/go/v0.2.29"
+        default: "protocol/go/v0.3.0"
 
 jobs:
   update-platform-branch:

--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -2,6 +2,9 @@ name: "Update Platform Branch"
 # This workflow updates the platform.branch property in all pom.xml files to a new tag or branch.
 # It is triggered by a manual dispatch or by a call from another workflow - notably from platform changes to protocol/go.
 # This property is used to select which versions of the protocol buffer definitions to use.
+#
+# To test:
+#   `act workflow_dispatch -W ./.github/workflows/update-platform-branch.yaml --input tag=protocol/go/v0.3.1`
 
 on:
   workflow_call:
@@ -27,7 +30,7 @@ jobs:
       - name: Validate tag as a valid git ref
         run: |
           TAG="${{ github.event.inputs.tag }}"
-          if ! [[ "$TAG" =~ ^[a-zA-Z0-9._\-/]+$ ]]; then
+          if ! echo "$TAG" | grep -Eq "^[a-zA-Z0-9._\-\/]+$"; then
             echo "Invalid tag format: [$TAG]"
             exit 1
           fi


### PR DESCRIPTION
Adds a dependabot-style workflow, `update-platform-branch`, which will bump the protocol buffer source tag, used during the generate-sources build phase for RPCs with the policy and key access services.

It runs on a schedule to create a dependabot/rennovate style PR,  but if you need to bump faster it supports manual dispatch, or, if we get it setup, repository dispatch to make it slightly more automated