### PR TITLE
fix(something): use `dokka-maven-plugin` instead of `javadoc-maven-plugin`

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -304,17 +304,15 @@
             </plugin>
             <!-- Plugin to create Javadoc JAR -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <sourceFileIncludes>${project.basedir}/src/main/**/*.java</sourceFileIncludes>
-                </configuration>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
-                        <id>attach-javadocs</id>
+                        <id>javadoc</id>
+                        <phase>package</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>javadocJar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
`javadoc` maven plugin doesn't understand Kotlin. `dokka` knows how to create javadoc from both Java and Kotlin