### PR TITLE
feat(sdk): Get the algorithm from the KASInfo and not the config

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
@@ -13,7 +13,7 @@ public class ECCMode {
     public ECCMode(byte value) {
         data = new ECCModeStruct();
         int curveMode = value & 0x07; // first 3 bits
-        setEllipticCurve(NanoTDFType.ECCurve.values()[curveMode]);
+        setEllipticCurve(NanoTDFType.ECCurve.fromCurveMode(curveMode));
         int useECDSABinding = (value >> 7) & 0x01; // most significant bit
         data.useECDSABinding = useECDSABinding;
     }
@@ -52,67 +52,14 @@ public class ECCMode {
         return data.useECDSABinding == 1;
     }
 
-    public String getCurveName() {
-        return getEllipticCurveName(NanoTDFType.ECCurve.values()[data.curveMode]);
-    }
-
     public byte getECCModeAsByte() {
         int value = (data.useECDSABinding << 7) | data.curveMode;
         return (byte) value;
     }
 
-    public static String getEllipticCurveName(NanoTDFType.ECCurve curve) {
-        switch (curve) {
-            case SECP256R1:
-                return "secp256r1";
-            case SECP384R1:
-                return "secp384r1";
-            case SECP521R1:
-                return "secp521r1";
-            case SECP256K1:
-                throw new RuntimeException("SDK doesn't support 'secp256k1' curve");
-            default:
-                throw new RuntimeException("Unsupported ECC algorithm.");
-        }
-    }
-
-    public static int getECKeySize(NanoTDFType.ECCurve curve) {
-        switch (curve) {
-            case SECP256K1:
-                throw new RuntimeException("SDK doesn't support 'secp256k1' curve");
-            case SECP256R1:
-                return 32;
-            case SECP384R1:
-                return 48;
-            case SECP521R1:
-                return 66;
-            default:
-                throw new RuntimeException("Unsupported ECC algorithm.");
-        }
-    }
-
     public static int getECDSASignatureStructSize(NanoTDFType.ECCurve curve) {
-        int keySize = getECKeySize(curve);
+        int keySize = curve.compressedPubKeySize;
         return (1 + keySize + 1 + keySize);
-    }
-
-    public static int getECKeySize(String curveName) {
-        return ECKeyPair.getECKeySize(curveName);
-    }
-
-    public static int getECCompressedPubKeySize(NanoTDFType.ECCurve curve) {
-        switch (curve) {
-            case SECP256K1:
-                throw new RuntimeException("SDK doesn't support 'secp256k1' curve");
-            case SECP256R1:
-                return 33;
-            case SECP384R1:
-                return 49;
-            case SECP521R1:
-                return 67;
-            default:
-                throw new RuntimeException("Unsupported ECC algorithm.");
-        }
     }
 
     private class ECCModeStruct {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
@@ -44,10 +44,6 @@ public class ECCMode {
         }
     }
 
-    public NanoTDFType.ECCurve getCurve() {
-        return NanoTDFType.ECCurve.values()[data.curveMode];
-    }
-
     public boolean isECDSABindingEnabled() {
         return data.useECDSABinding == 1;
     }
@@ -60,6 +56,10 @@ public class ECCMode {
     public static int getECDSASignatureStructSize(NanoTDFType.ECCurve curve) {
         int keySize = curve.compressedPubKeySize;
         return (1 + keySize + 1 + keySize);
+    }
+
+    public NanoTDFType.ECCurve getCurve() {
+        return NanoTDFType.ECCurve.fromCurveMode(data.curveMode);
     }
 
     private class ECCModeStruct {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
@@ -54,7 +54,7 @@ public class ECCMode {
     }
 
     public static int getECDSASignatureStructSize(NanoTDFType.ECCurve curve) {
-        int keySize = curve.compressedPubKeySize;
+        int keySize = curve.keySize;
         return (1 + keySize + 1 + keySize);
     }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
@@ -54,7 +54,7 @@ public class ECCMode {
     }
 
     public static int getECDSASignatureStructSize(NanoTDFType.ECCurve curve) {
-        int keySize = curve.keySize;
+        int keySize = curve.getKeySize();
         return (1 + keySize + 1 + keySize);
     }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
@@ -1,5 +1,7 @@
 package io.opentdf.platform.sdk;
 
+import javax.annotation.Nonnull;
+
 public class ECCMode {
     private ECCModeStruct data;
 
@@ -58,6 +60,8 @@ public class ECCMode {
         return (1 + keySize + 1 + keySize);
     }
 
+
+    @Nonnull
     public NanoTDFType.ECCurve getCurve() {
         return NanoTDFType.ECCurve.fromCurveMode(data.curveMode);
     }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECCMode.java
@@ -44,7 +44,7 @@ public class ECCMode {
         }
     }
 
-    public NanoTDFType.ECCurve getEllipticCurveType() {
+    public NanoTDFType.ECCurve getCurve() {
         return NanoTDFType.ECCurve.values()[data.curveMode];
     }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
@@ -24,6 +24,7 @@ import javax.crypto.KeyAgreement;
 import java.io.*;
 import java.security.*;
 import java.security.spec.*;
+import java.util.Objects;
 // https://www.bouncycastle.org/latest_releases.html
 
 public class ECKeyPair {
@@ -48,7 +49,7 @@ public class ECKeyPair {
     }
 
     public ECKeyPair(NanoTDFType.ECCurve curve, ECAlgorithm algorithm) {
-        this.curve = curve;
+        this.curve = Objects.requireNonNull(curve);
         KeyPairGenerator generator;
 
         try {
@@ -78,6 +79,10 @@ public class ECKeyPair {
 
     public ECPrivateKey getPrivateKey() {
         return (ECPrivateKey) this.keyPair.getPrivate();
+    }
+
+    NanoTDFType.ECCurve getCurve() {
+        return this.curve;
     }
 
     public String publicKeyInPEMFormat() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
@@ -32,6 +32,8 @@ public class ECKeyPair {
         Security.addProvider(new BouncyCastleProvider());
     }
 
+    private final NanoTDFType.ECCurve curve;
+
     public enum ECAlgorithm {
         ECDH,
         ECDSA
@@ -40,13 +42,13 @@ public class ECKeyPair {
     private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
 
     private KeyPair keyPair;
-    private String curveName;
 
     public ECKeyPair() {
-        this("secp256r1", ECAlgorithm.ECDH);
+        this(NanoTDFType.ECCurve.SECP256R1, ECAlgorithm.ECDH);
     }
 
-    public ECKeyPair(String curveName, ECAlgorithm algorithm) {
+    public ECKeyPair(NanoTDFType.ECCurve curve, ECAlgorithm algorithm) {
+        this.curve = curve;
         KeyPairGenerator generator;
 
         try {
@@ -61,19 +63,13 @@ public class ECKeyPair {
             throw new RuntimeException(e);
         }
 
-        ECGenParameterSpec spec = new ECGenParameterSpec(curveName);
+        ECGenParameterSpec spec = new ECGenParameterSpec(this.curve.curveName);
         try {
             generator.initialize(spec);
         } catch (InvalidAlgorithmParameterException e) {
             throw new RuntimeException(e);
         }
         this.keyPair = generator.generateKeyPair();
-        this.curveName = curveName;
-    }
-
-    public ECKeyPair(ECPublicKey publicKey, ECPrivateKey privateKey, String curveName) {
-        this.keyPair = new KeyPair(publicKey, privateKey);
-        this.curveName = curveName;
     }
 
     public ECPublicKey getPublicKey() {
@@ -116,10 +112,6 @@ public class ECKeyPair {
 
     public int keySize() {
         return this.keyPair.getPrivate().getEncoded().length * 8;
-    }
-
-    public String curveName() {
-        return this.curveName;
     }
 
     public byte[] compressECPublickey() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
@@ -64,7 +64,7 @@ public class ECKeyPair {
             throw new RuntimeException(e);
         }
 
-        ECGenParameterSpec spec = new ECGenParameterSpec(this.curve.curveName);
+        ECGenParameterSpec spec = new ECGenParameterSpec(this.curve.getCurveName());
         try {
             generator.initialize(spec);
         } catch (InvalidAlgorithmParameterException e) {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/ECKeyPair.java
@@ -39,30 +39,6 @@ public class ECKeyPair {
 
     private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
 
-    public enum NanoTDFECCurve {
-        SECP256R1("secp256r1", KeyType.EC256Key),
-        PRIME256V1("prime256v1", KeyType.EC256Key),
-        SECP384R1("secp384r1", KeyType.EC384Key),
-        SECP521R1("secp521r1", KeyType.EC521Key);
-
-        private String name;
-        private KeyType keyType;
-
-        NanoTDFECCurve(String curveName, KeyType keyType) {
-            this.name = curveName;
-            this.keyType = keyType;
-        }
-
-        @Override
-        public String toString() {
-            return name;
-        }
-
-        public KeyType getKeyType() {
-            return keyType;
-        }
-    }
-
     private KeyPair keyPair;
     private String curveName;
 
@@ -106,19 +82,6 @@ public class ECKeyPair {
 
     public ECPrivateKey getPrivateKey() {
         return (ECPrivateKey) this.keyPair.getPrivate();
-    }
-
-    public static int getECKeySize(String curveName) {
-        if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP256R1.toString()) ||
-                curveName.equalsIgnoreCase(NanoTDFECCurve.PRIME256V1.toString())) {
-            return 32;
-        } else if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP384R1.toString())) {
-            return 48;
-        } else if (curveName.equalsIgnoreCase(NanoTDFECCurve.SECP521R1.toString())) {
-            return 66;
-        } else {
-            throw new IllegalArgumentException("Unsupported ECC algorithm.");
-        }
     }
 
     public String publicKeyInPEMFormat() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
@@ -26,7 +26,7 @@ public class Header {
         this.payloadConfig = new SymmetricAndPayloadConfig(buffer.get());
         this.policyInfo = new PolicyInfo(buffer, this.eccMode);
 
-        int compressedPubKeySize = this.eccMode.getEllipticCurveType().keySize;
+        int compressedPubKeySize = this.eccMode.getCurve().keySize;
         this.ephemeralKey = new byte[compressedPubKeySize];
         buffer.get(this.ephemeralKey);
     }
@@ -79,10 +79,10 @@ public class Header {
     }
 
     public void setEphemeralKey(byte[] bytes) {
-        if (bytes.length < eccMode.getEllipticCurveType().keySize) {
+        if (bytes.length < eccMode.getCurve().keySize) {
             throw new IllegalArgumentException("Failed to read ephemeral key - invalid buffer size.");
         }
-        ephemeralKey = Arrays.copyOf(bytes, eccMode.getEllipticCurveType().keySize);
+        ephemeralKey = Arrays.copyOf(bytes, eccMode.getCurve().keySize);
     }
 
     public byte[] getEphemeralKey() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
@@ -26,7 +26,7 @@ public class Header {
         this.payloadConfig = new SymmetricAndPayloadConfig(buffer.get());
         this.policyInfo = new PolicyInfo(buffer, this.eccMode);
 
-        int compressedPubKeySize = this.eccMode.getCurve().keySize;
+        int compressedPubKeySize = this.eccMode.getCurve().compressedPubKeySize;
         this.ephemeralKey = new byte[compressedPubKeySize];
         buffer.get(this.ephemeralKey);
     }
@@ -79,10 +79,10 @@ public class Header {
     }
 
     public void setEphemeralKey(byte[] bytes) {
-        if (bytes.length < eccMode.getCurve().keySize) {
+        if (bytes.length < eccMode.getCurve().compressedPubKeySize) {
             throw new IllegalArgumentException("Failed to read ephemeral key - invalid buffer size.");
         }
-        ephemeralKey = Arrays.copyOf(bytes, eccMode.getCurve().keySize);
+        ephemeralKey = Arrays.copyOf(bytes, eccMode.getCurve().compressedPubKeySize);
     }
 
     public byte[] getEphemeralKey() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
@@ -26,7 +26,7 @@ public class Header {
         this.payloadConfig = new SymmetricAndPayloadConfig(buffer.get());
         this.policyInfo = new PolicyInfo(buffer, this.eccMode);
 
-        int compressedPubKeySize = ECCMode.getECCompressedPubKeySize(this.eccMode.getEllipticCurveType());
+        int compressedPubKeySize = this.eccMode.getEllipticCurveType().keySize;
         this.ephemeralKey = new byte[compressedPubKeySize];
         buffer.get(this.ephemeralKey);
     }
@@ -79,10 +79,10 @@ public class Header {
     }
 
     public void setEphemeralKey(byte[] bytes) {
-        if (bytes.length < eccMode.getECCompressedPubKeySize(eccMode.getEllipticCurveType())) {
+        if (bytes.length < eccMode.getEllipticCurveType().keySize) {
             throw new IllegalArgumentException("Failed to read ephemeral key - invalid buffer size.");
         }
-        ephemeralKey = Arrays.copyOf(bytes, eccMode.getECCompressedPubKeySize(eccMode.getEllipticCurveType()));
+        ephemeralKey = Arrays.copyOf(bytes, eccMode.getEllipticCurveType().keySize);
     }
 
     public byte[] getEphemeralKey() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Header.java
@@ -26,7 +26,7 @@ public class Header {
         this.payloadConfig = new SymmetricAndPayloadConfig(buffer.get());
         this.policyInfo = new PolicyInfo(buffer, this.eccMode);
 
-        int compressedPubKeySize = this.eccMode.getCurve().compressedPubKeySize;
+        int compressedPubKeySize = this.eccMode.getCurve().getCompressedPubKeySize();
         this.ephemeralKey = new byte[compressedPubKeySize];
         buffer.get(this.ephemeralKey);
     }
@@ -79,10 +79,10 @@ public class Header {
     }
 
     public void setEphemeralKey(byte[] bytes) {
-        if (bytes.length < eccMode.getCurve().compressedPubKeySize) {
+        if (bytes.length < eccMode.getCurve().getCompressedPubKeySize()) {
             throw new IllegalArgumentException("Failed to read ephemeral key - invalid buffer size.");
         }
-        ephemeralKey = Arrays.copyOf(bytes, eccMode.getCurve().compressedPubKeySize);
+        ephemeralKey = Arrays.copyOf(bytes, eccMode.getCurve().getCompressedPubKeySize());
     }
 
     public byte[] getEphemeralKey() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -21,6 +21,8 @@ import io.opentdf.platform.sdk.Config.KASInfo;
 import io.opentdf.platform.sdk.SDK.KasBadRequestException;
 
 import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -49,6 +51,8 @@ class KASClient implements SDK.KAS {
     private String clientPublicKey;
     private KASKeyCache kasKeyCache;
 
+    private static final Logger log = LoggerFactory.getLogger(KASClient.class);
+
     /***
      * A client that communicates with KAS
      * 
@@ -69,7 +73,9 @@ class KASClient implements SDK.KAS {
 
     @Override
     public KASInfo getECPublicKey(Config.KASInfo kasInfo, NanoTDFType.ECCurve curve) {
-        var req = PublicKeyRequest.newBuilder().setAlgorithm(format("ec:%s", curve.toString())).build();
+        log.debug("retrieving public key with kasinfo = [{}]", kasInfo);
+
+        var req = PublicKeyRequest.newBuilder().setAlgorithm(format("ec:%s", curve.curveName)).build();
         var r = getStub(kasInfo.URL).publicKeyBlocking(req, Collections.emptyMap()).execute();
         PublicKeyResponse res;
         try {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -147,9 +147,8 @@ class KASClient implements SDK.KAS {
     @Override
     public byte[] unwrap(Manifest.KeyAccess keyAccess, String policy,  KeyType sessionKeyType) {
         ECKeyPair ecKeyPair = null;
-
         if (sessionKeyType.isEc()) {
-            var curve = sessionKeyType.getECEcurve().get();
+            var curve = sessionKeyType.getECCurve();
             ecKeyPair = new ECKeyPair(curve, ECKeyPair.ECAlgorithm.ECDH);
             clientPublicKey = ecKeyPair.publicKeyInPEMFormat();
         } else {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -149,8 +149,8 @@ class KASClient implements SDK.KAS {
         ECKeyPair ecKeyPair = null;
 
         if (sessionKeyType.isEc()) {
-            var curveName = sessionKeyType.getCurveName();
-            ecKeyPair = new ECKeyPair(curveName, ECKeyPair.ECAlgorithm.ECDH);
+            var curve = sessionKeyType.getECEcurve().get();
+            ecKeyPair = new ECKeyPair(curve.curveName, ECKeyPair.ECAlgorithm.ECDH);
             clientPublicKey = ecKeyPair.publicKeyInPEMFormat();
         } else {
             // Initialize the RSA key pair only once and reuse it for future unwrap operations

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -75,7 +75,7 @@ class KASClient implements SDK.KAS {
     public KASInfo getECPublicKey(Config.KASInfo kasInfo, NanoTDFType.ECCurve curve) {
         log.debug("retrieving public key with kasinfo = [{}]", kasInfo);
 
-        var req = PublicKeyRequest.newBuilder().setAlgorithm(format("ec:%s", curve.curveName)).build();
+        var req = PublicKeyRequest.newBuilder().setAlgorithm(curve.getPlatformCurveName()).build();
         var r = getStub(kasInfo.URL).publicKeyBlocking(req, Collections.emptyMap()).execute();
         PublicKeyResponse res;
         try {
@@ -233,7 +233,7 @@ class KASClient implements SDK.KAS {
         keyAccess.protocol = "kas";
 
         NanoTDFRewrapRequestBody body = new NanoTDFRewrapRequestBody();
-        body.algorithm = format("ec:%s", curve.curveName);
+        body.algorithm = format("ec:%s", curve.getCurveName());
         body.clientPublicKey = keyPair.publicKeyInPEMFormat();
         body.keyAccess = keyAccess;
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -203,7 +203,7 @@ class KASClient implements SDK.KAS {
         }
 
         var wrappedKey = response.getEntityWrappedKey().toByteArray();
-        if (sessionKeyType != KeyType.RSA2048Key) {
+        if (sessionKeyType.isEc()) {
 
             if (ecKeyPair == null) {
                 throw new SDKException("ECKeyPair is null. Unable to proceed with the unwrap operation.");
@@ -233,7 +233,7 @@ class KASClient implements SDK.KAS {
         keyAccess.protocol = "kas";
 
         NanoTDFRewrapRequestBody body = new NanoTDFRewrapRequestBody();
-        body.algorithm = format("ec:%s", curve.toString());
+        body.algorithm = format("ec:%s", curve.curveName);
         body.clientPublicKey = keyPair.publicKeyInPEMFormat();
         body.keyAccess = keyAccess;
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KASClient.java
@@ -150,7 +150,7 @@ class KASClient implements SDK.KAS {
 
         if (sessionKeyType.isEc()) {
             var curve = sessionKeyType.getECEcurve().get();
-            ecKeyPair = new ECKeyPair(curve.curveName, ECKeyPair.ECAlgorithm.ECDH);
+            ecKeyPair = new ECKeyPair(curve, ECKeyPair.ECAlgorithm.ECDH);
             clientPublicKey = ecKeyPair.publicKeyInPEMFormat();
         } else {
             // Initialize the RSA key pair only once and reuse it for future unwrap operations
@@ -219,7 +219,7 @@ class KASClient implements SDK.KAS {
     }
 
     public byte[] unwrapNanoTDF(NanoTDFType.ECCurve curve, String header, String kasURL) {
-        ECKeyPair keyPair = new ECKeyPair(curve.toString(), ECKeyPair.ECAlgorithm.ECDH);
+        ECKeyPair keyPair = new ECKeyPair(curve, ECKeyPair.ECAlgorithm.ECDH);
 
         NanoTDFKeyAccess keyAccess = new NanoTDFKeyAccess();
         keyAccess.header = header;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
@@ -1,6 +1,6 @@
 package io.opentdf.platform.sdk;
 
-import java.util.Optional;
+import javax.annotation.Nonnull;
 
 import static io.opentdf.platform.sdk.NanoTDFType.ECCurve.SECP256R1;
 import static io.opentdf.platform.sdk.NanoTDFType.ECCurve.SECP384R1;
@@ -24,15 +24,18 @@ public enum KeyType {
         this(keyType, null);
     }
 
-    public Optional<NanoTDFType.ECCurve> getECEcurve() {
-        return Optional.ofNullable(curve);
+    @Nonnull
+    NanoTDFType.ECCurve getECCurve() {
+        if (!isEc()) {
+            throw new IllegalStateException("This key type does not have an ECCurve associated with it: " + keyType);
+        }
+        return curve;
     }
 
     @Override
     public String toString() {
         return keyType;
     }
-
 
     public static KeyType fromString(String keyType) {
         for (KeyType type : KeyType.values()) {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
@@ -1,15 +1,31 @@
 package io.opentdf.platform.sdk;
 
+import java.util.Optional;
+
+import static io.opentdf.platform.sdk.NanoTDFType.ECCurve.SECP256R1;
+import static io.opentdf.platform.sdk.NanoTDFType.ECCurve.SECP384R1;
+import static io.opentdf.platform.sdk.NanoTDFType.ECCurve.SECP521R1;
+
 public enum KeyType {
     RSA2048Key("rsa:2048"),
-    EC256Key("ec:secp256r1"),
-    EC384Key("ec:secp384r1"),
-    EC521Key("ec:secp521r1");
+    EC256Key("ec:secp256r1", SECP256R1),
+    EC384Key("ec:secp384r1", SECP384R1),
+    EC521Key("ec:secp521r1", SECP521R1);
 
     private final String keyType;
+    private final NanoTDFType.ECCurve curve;
+
+    KeyType(String keyType, NanoTDFType.ECCurve ecCurve) {
+        this.keyType = keyType;
+        this.curve = ecCurve;
+    }
 
     KeyType(String keyType) {
-        this.keyType = keyType;
+        this(keyType, null);
+    }
+
+    public Optional<NanoTDFType.ECCurve> getECEcurve() {
+        return Optional.ofNullable(curve);
     }
 
     @Override
@@ -17,18 +33,6 @@ public enum KeyType {
         return keyType;
     }
 
-    public String getCurveName() {
-        switch (this) {
-            case EC256Key:
-                return "secp256r1";
-            case EC384Key:
-                return "secp384r1";
-            case EC521Key:
-                return "secp521r1";
-            default:
-                throw new IllegalArgumentException("Unsupported key type: " + this);
-        }
-    }
 
     public static KeyType fromString(String keyType) {
         for (KeyType type : KeyType.values()) {
@@ -40,6 +44,6 @@ public enum KeyType {
     }
 
     public boolean isEc() {
-        return this != RSA2048Key;
+        return this.curve != null;
     }
 }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
@@ -89,7 +89,7 @@ class NanoTDF {
         ResourceLocator kasURL = new ResourceLocator(nanoTDFConfig.kasInfoList.get(0).URL, kasInfo.KID);
         assert kasURL.getIdentifier() != null : "Identifier in ResourceLocator cannot be null";
 
-        ECKeyPair keyPair = new ECKeyPair(nanoTDFConfig.eccMode.getCurveName(), ECKeyPair.ECAlgorithm.ECDSA);
+        ECKeyPair keyPair = new ECKeyPair(nanoTDFConfig.eccMode.getEllipticCurveType().curveName, ECKeyPair.ECAlgorithm.ECDSA);
 
         // Generate symmetric key
         ECPublicKey kasPublicKey = ECKeyPair.publicKeyFromPem(kasInfo.PublicKey);

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
@@ -89,7 +89,7 @@ class NanoTDF {
         ResourceLocator kasURL = new ResourceLocator(nanoTDFConfig.kasInfoList.get(0).URL, kasInfo.KID);
         assert kasURL.getIdentifier() != null : "Identifier in ResourceLocator cannot be null";
 
-        ECKeyPair keyPair = new ECKeyPair(nanoTDFConfig.eccMode.getEllipticCurveType().curveName, ECKeyPair.ECAlgorithm.ECDSA);
+        ECKeyPair keyPair = new ECKeyPair(nanoTDFConfig.eccMode.getEllipticCurveType(), ECKeyPair.ECAlgorithm.ECDSA);
 
         // Generate symmetric key
         ECPublicKey kasPublicKey = ECKeyPair.publicKeyFromPem(kasInfo.PublicKey);

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDF.java
@@ -82,14 +82,20 @@ class NanoTDF {
         String url = kasInfo.URL;
         if (kasInfo.PublicKey == null || kasInfo.PublicKey.isEmpty()) {
             logger.info("no public key provided for KAS at {}, retrieving", url);
-            kasInfo = services.kas().getECPublicKey(kasInfo, nanoTDFConfig.eccMode.getEllipticCurveType());
+            kasInfo = services.kas().getECPublicKey(kasInfo, nanoTDFConfig.eccMode.getCurve());
         }
 
         // Kas url resource locator
         ResourceLocator kasURL = new ResourceLocator(nanoTDFConfig.kasInfoList.get(0).URL, kasInfo.KID);
         assert kasURL.getIdentifier() != null : "Identifier in ResourceLocator cannot be null";
 
-        ECKeyPair keyPair = new ECKeyPair(nanoTDFConfig.eccMode.getEllipticCurveType(), ECKeyPair.ECAlgorithm.ECDSA);
+        // it might be better to pull the curve from the OIDC in the PEM but it looks like we
+        // are just taking the Algorithm as correct
+        var ecCurve = NanoTDFType.ECCurve.fromAlgorithm(kasInfo.Algorithm);
+        if (ecCurve != nanoTDFConfig.eccMode.getCurve()) {
+            logger.warn("ECCurve in NanoTDFConfig [{}] does not match the curve in KASInfo, using KASInfo curve [{}]", nanoTDFConfig.eccMode.getCurve(), ecCurve);
+        }
+        ECKeyPair keyPair = new ECKeyPair(ecCurve, ECKeyPair.ECAlgorithm.ECDSA);
 
         // Generate symmetric key
         ECPublicKey kasPublicKey = ECKeyPair.publicKeyFromPem(kasInfo.PublicKey);
@@ -138,7 +144,14 @@ class NanoTDF {
         // Create header
         byte[] compressedPubKey = keyPair.compressECPublickey();
         Header header = new Header();
-        header.setECCMode(nanoTDFConfig.eccMode);
+        ECCMode mode;
+        if (nanoTDFConfig.eccMode.getCurve() != keyPair.getCurve()) {
+            mode = new ECCMode(nanoTDFConfig.eccMode.getECCModeAsByte());
+            mode.setEllipticCurve(keyPair.getCurve());
+        } else {
+            mode = nanoTDFConfig.eccMode;
+        }
+        header.setECCMode(mode);
         header.setPayloadConfig(nanoTDFConfig.config);
         header.setEphemeralKey(compressedPubKey);
         header.setKasLocator(kasURL);
@@ -276,7 +289,7 @@ class NanoTDF {
             }
 
 
-            key = services.kas().unwrapNanoTDF(header.getECCMode().getEllipticCurveType(),
+            key = services.kas().unwrapNanoTDF(header.getECCMode().getCurve(),
                     base64HeaderData,
                     kasUrl);
             collectionStore.store(header, new CollectionKey(key));

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -1,6 +1,12 @@
 package io.opentdf.platform.sdk;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
 public class NanoTDFType {
+    private static final Logger log = LoggerFactory.getLogger(NanoTDFType.class);
     enum ECCurve {
         SECP256R1("secp256r1", 32, 33, 0x00),
         SECP384R1("secp384r1", 48, 49, 0x01),
@@ -33,6 +39,20 @@ public class NanoTDFType {
                 }
             }
             throw new IllegalArgumentException("No enum constant for curve mode: " + curveMode);
+        }
+
+        public static ECCurve fromAlgorithm(String algorithm) {
+            if (algorithm == null) {
+                log.warn("got a null algorithm, returning SECP256R1 as default");
+                return SECP256R1;
+            }
+
+            assert algorithm.startsWith("ec:");
+            var searchKey = algorithm.substring("ec:".length());
+            return Arrays.stream(ECCurve.values())
+                    .filter(v -> v.curveName.equalsIgnoreCase(searchKey))
+                    .findAny()
+                    .orElseThrow(() -> new IllegalArgumentException(String.format("No enum constant for algorithm: %s", algorithm)));
         }
     }
     // ResourceLocator Protocol

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -14,11 +14,11 @@ public class NanoTDFType {
         SECP521R1("secp521r1", 66, 67, 0x02),
         SECP256K1("secp256k1",-1, -1, -1, false); // Note: SECP256K1 is not supported by the SDK
 
-        final int curveMode;
-        final int keySize;
-        final int compressedPubKeySize;
-        final String curveName;
-        final boolean isSupported;
+        private final int curveMode;
+        private final int keySize;
+        private final int compressedPubKeySize;
+        private final String curveName;
+        private final boolean isSupported;
 
 
         ECCurve(String curveName, int keySize, int compressedPubKeySize, int curveMode) {
@@ -35,22 +35,45 @@ public class NanoTDFType {
 
         static ECCurve fromCurveMode(int curveMode) {
             for (ECCurve curve : ECCurve.values()) {
-                if (curve.curveMode == curveMode) {
+                if (curve.getCurveMode() == curveMode) {
                     return curve;
                 }
             }
             throw new IllegalArgumentException("No enum constant for curve mode: " + curveMode);
         }
 
-        static ECCurve fromAlgorithm(String algorithm) {
-            Objects.requireNonNull(algorithm, "Algorithm cannot be null");
+        static ECCurve fromAlgorithm(String platformAlgorithm) {
+            Objects.requireNonNull(platformAlgorithm, "Algorithm cannot be null");
 
-            var searchKey = algorithm.startsWith("ec:") ? algorithm.substring("ec:".length()) : algorithm;
-            log.debug("looking for algorithm [{}]", searchKey);
+            log.debug("looking for platformAlgorithm [{}]", platformAlgorithm);
             return Arrays.stream(ECCurve.values())
-                    .filter(v -> v.curveName.equalsIgnoreCase(searchKey))
+                    .filter(v -> v.getPlatformCurveName().equals(platformAlgorithm))
                     .findAny()
-                    .orElseThrow(() -> new IllegalArgumentException(String.format("No enum constant for algorithm: %s", algorithm)));
+                    .orElseThrow(() -> new IllegalArgumentException(String.format("No enum constant for platformAlgorithm: %s", platformAlgorithm)));
+        }
+
+        int getCurveMode() {
+            return curveMode;
+        }
+
+        int getKeySize() {
+            return keySize;
+        }
+
+        int getCompressedPubKeySize() {
+            return compressedPubKeySize;
+        }
+
+        String getCurveName() {
+            return curveName;
+        }
+
+        String getPlatformCurveName() {
+            return String.format("ec:%s", curveName);
+        }
+
+        boolean isSupported() {
+            return isSupported;
         }
     }
     // ResourceLocator Protocol

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -4,7 +4,7 @@ public class NanoTDFType {
     enum ECCurve {
         SECP256R1("secp256r1", 32, 33, 0x00),
         SECP384R1("secp384r1", 48, 49, 0x01),
-        SECP521R1("secp512r1", 66, 67, 0x02),
+        SECP521R1("secp521r1", 66, 67, 0x02),
         SECP256K1("secp256k1",-1, -1, -1, false); // Note: SECP256K1 is not supported by the SDK
 
         final int curveMode;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -17,6 +17,8 @@ public class NanoTDFType {
 
         private final int curveMode;
         private final int keySize;
+        // compressedPubKeySize is a byte bigger since it encodes the X coordinate plus a byte that tells
+        // if the Y coordinate is positive or negative
         private final int compressedPubKeySize;
         private final String curveName;
         private final boolean isSupported;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -3,8 +3,10 @@ package io.opentdf.platform.sdk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 
 public class NanoTDFType {
     private static final Logger log = LoggerFactory.getLogger(NanoTDFType.class);
@@ -33,6 +35,7 @@ public class NanoTDFType {
             this.isSupported = isSupported;
         }
 
+        @Nonnull
         static ECCurve fromCurveMode(int curveMode) {
             for (ECCurve curve : ECCurve.values()) {
                 if (curve.getCurveMode() == curveMode) {
@@ -42,14 +45,14 @@ public class NanoTDFType {
             throw new IllegalArgumentException("No enum constant for curve mode: " + curveMode);
         }
 
-        static ECCurve fromAlgorithm(String platformAlgorithm) {
-            Objects.requireNonNull(platformAlgorithm, "Algorithm cannot be null");
-
+        static Optional<ECCurve> fromAlgorithm(String platformAlgorithm) {
             log.debug("looking for platformAlgorithm [{}]", platformAlgorithm);
+            if (platformAlgorithm == null) {
+                return Optional.empty();
+            }
             return Arrays.stream(ECCurve.values())
                     .filter(v -> v.getPlatformCurveName().equals(platformAlgorithm))
-                    .findAny()
-                    .orElseThrow(() -> new IllegalArgumentException(String.format("No enum constant for platformAlgorithm: %s", platformAlgorithm)));
+                    .findAny();
         }
 
         int getCurveMode() {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class NanoTDFType {
     private static final Logger log = LoggerFactory.getLogger(NanoTDFType.class);
@@ -42,10 +43,8 @@ public class NanoTDFType {
         }
 
         static ECCurve fromAlgorithm(String algorithm) {
-            if (algorithm == null) {
-                log.warn("got a null algorithm, returning SECP256R1 as default");
-                return SECP256R1;
-            }
+            Objects.requireNonNull(algorithm, "Algorithm cannot be null");
+
             var searchKey = algorithm.startsWith("ec:") ? algorithm.substring("ec:".length()) : algorithm;
             log.debug("looking for algorithm [{}]", searchKey);
             return Arrays.stream(ECCurve.values())

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -1,21 +1,38 @@
 package io.opentdf.platform.sdk;
 
 public class NanoTDFType {
-    public enum ECCurve {
-        SECP256R1("secp256r1"),
-        SECP384R1("secp384r1"),
-        SECP521R1("secp384r1"),
-        SECP256K1("secp256k1");
+    enum ECCurve {
+        SECP256R1("secp256r1", 32, 33, 0x00),
+        SECP384R1("secp384r1", 48, 49, 0x01),
+        SECP521R1("secp512r1", 66, 67, 0x02),
+        SECP256K1("secp256k1",-1, -1, -1, false); // Note: SECP256K1 is not supported by the SDK
 
-        private final String name;
+        final int curveMode;
+        final int keySize;
+        final int compressedPubKeySize;
+        final String curveName;
+        final boolean isSupported;
 
-        ECCurve(String curveName) {
-            this.name = curveName;
+
+        ECCurve(String curveName, int compressedPubKeySize, int keySize, int curveMode) {
+            this(curveName, compressedPubKeySize, keySize, curveMode, true);
         }
 
-        @Override
-        public String toString() {
-            return name;
+        ECCurve(String curveName, int compressedPubKeySize, int keySize, int curveMode, boolean isSupported) {
+            this.compressedPubKeySize = compressedPubKeySize;
+            this.keySize = keySize;
+            this.curveMode = curveMode;
+            this.curveName = curveName ;
+            this.isSupported = isSupported;
+        }
+
+        static ECCurve fromCurveMode(int curveMode) {
+            for (ECCurve curve : ECCurve.values()) {
+                if (curve.curveMode == curveMode) {
+                    return curve;
+                }
+            }
+            throw new IllegalArgumentException("No enum constant for curve mode: " + curveMode);
         }
     }
     // ResourceLocator Protocol

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -21,14 +21,14 @@ public class NanoTDFType {
 
 
         ECCurve(String curveName, int keySize, int compressedPubKeySize, int curveMode) {
-            this(curveName, compressedPubKeySize, keySize, curveMode, true);
+            this(curveName, keySize, compressedPubKeySize, curveMode, true);
         }
 
         ECCurve(String curveName, int keySize, int compressedPubKeySize, int curveMode, boolean isSupported) {
-            this.compressedPubKeySize = compressedPubKeySize;
-            this.keySize = keySize;
-            this.curveMode = curveMode;
             this.curveName = curveName ;
+            this.keySize = keySize;
+            this.compressedPubKeySize = compressedPubKeySize;
+            this.curveMode = curveMode;
             this.isSupported = isSupported;
         }
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -20,11 +20,11 @@ public class NanoTDFType {
         final boolean isSupported;
 
 
-        ECCurve(String curveName, int compressedPubKeySize, int keySize, int curveMode) {
+        ECCurve(String curveName, int keySize, int compressedPubKeySize, int curveMode) {
             this(curveName, compressedPubKeySize, keySize, curveMode, true);
         }
 
-        ECCurve(String curveName, int compressedPubKeySize, int keySize, int curveMode, boolean isSupported) {
+        ECCurve(String curveName, int keySize, int compressedPubKeySize, int curveMode, boolean isSupported) {
             this.compressedPubKeySize = compressedPubKeySize;
             this.keySize = keySize;
             this.curveMode = curveMode;

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Optional;
 
 public class NanoTDFType {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/NanoTDFType.java
@@ -41,14 +41,13 @@ public class NanoTDFType {
             throw new IllegalArgumentException("No enum constant for curve mode: " + curveMode);
         }
 
-        public static ECCurve fromAlgorithm(String algorithm) {
+        static ECCurve fromAlgorithm(String algorithm) {
             if (algorithm == null) {
                 log.warn("got a null algorithm, returning SECP256R1 as default");
                 return SECP256R1;
             }
-
-            assert algorithm.startsWith("ec:");
-            var searchKey = algorithm.substring("ec:".length());
+            var searchKey = algorithm.startsWith("ec:") ? algorithm.substring("ec:".length()) : algorithm;
+            log.debug("looking for algorithm [{}]", searchKey);
             return Arrays.stream(ECCurve.values())
                     .filter(v -> v.curveName.equalsIgnoreCase(searchKey))
                     .findAny()

--- a/sdk/src/main/java/io/opentdf/platform/sdk/PolicyInfo.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/PolicyInfo.java
@@ -47,7 +47,7 @@ public class PolicyInfo {
 
         int bindingBytesSize = 8; // GMAC length
         if (this.hasECDSABinding) { // ECDSA - The size of binding depends on the curve.
-            bindingBytesSize = ECCMode.getECDSASignatureStructSize(eccMode.getEllipticCurveType());
+            bindingBytesSize = ECCMode.getECDSASignatureStructSize(eccMode.getCurve());
         }
 
         this.binding = new byte[bindingBytesSize];

--- a/sdk/src/main/java/io/opentdf/platform/sdk/SymmetricAndPayloadConfig.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/SymmetricAndPayloadConfig.java
@@ -1,7 +1,5 @@
 package io.opentdf.platform.sdk;
 
-import io.opentdf.platform.policy.Key;
-
 public class SymmetricAndPayloadConfig {
     private Data data;
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/SymmetricAndPayloadConfig.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/SymmetricAndPayloadConfig.java
@@ -28,10 +28,10 @@ public class SymmetricAndPayloadConfig {
     }
 
     public void setSignatureECCMode(NanoTDFType.ECCurve eccCurve) {
-        if (!eccCurve.isSupported) {
-            throw new RuntimeException(String.format("Unsupported ECC algorithm: %s", eccCurve.curveName));
+        if (!eccCurve.isSupported()) {
+            throw new SDKException(String.format("Unsupported ECC algorithm: %s", eccCurve.getCurveName()));
         }
-        data.signatureECCMode = eccCurve.curveMode;
+        data.signatureECCMode = eccCurve.getCurveMode();
     }
 
     public void setSymmetricCipherType(NanoTDFType.Cipher cipherType) {

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -279,7 +279,7 @@ class TDF {
         private ECKeyWrappedKeyInfo createECWrappedKey(Config.TDFConfig tdfConfig, Config.KASInfo kasInfo, byte[] symKey)  {
             var curve = tdfConfig.wrappingKeyType.getECEcurve().get();
             assert curve != null : "Wrapping key type must be an EC key type";
-            var keyPair = new ECKeyPair(curve.curveName, ECKeyPair.ECAlgorithm.ECDH);
+            var keyPair = new ECKeyPair(curve, ECKeyPair.ECAlgorithm.ECDH);
 
             ECPublicKey kasPubKey = ECKeyPair.publicKeyFromPem(kasInfo.PublicKey);
             byte[] symmetricKey = ECKeyPair.computeECDHKey(kasPubKey, keyPair.getPrivateKey());

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -277,8 +277,7 @@ class TDF {
         }
 
         private ECKeyWrappedKeyInfo createECWrappedKey(Config.TDFConfig tdfConfig, Config.KASInfo kasInfo, byte[] symKey)  {
-            var curve = tdfConfig.wrappingKeyType.getECEcurve().get();
-            assert curve != null : "Wrapping key type must be an EC key type";
+            var curve = tdfConfig.wrappingKeyType.getECCurve();
             var keyPair = new ECKeyPair(curve, ECKeyPair.ECAlgorithm.ECDH);
 
             ECPublicKey kasPubKey = ECKeyPair.publicKeyFromPem(kasInfo.PublicKey);

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -277,8 +277,9 @@ class TDF {
         }
 
         private ECKeyWrappedKeyInfo createECWrappedKey(Config.TDFConfig tdfConfig, Config.KASInfo kasInfo, byte[] symKey)  {
-            var curveName = tdfConfig.wrappingKeyType.getCurveName();
-            var keyPair = new ECKeyPair(curveName, ECKeyPair.ECAlgorithm.ECDH);
+            var curve = tdfConfig.wrappingKeyType.getECEcurve().get();
+            assert curve != null : "Wrapping key type must be an EC key type";
+            var keyPair = new ECKeyPair(curve.curveName, ECKeyPair.ECAlgorithm.ECDH);
 
             ECPublicKey kasPubKey = ECKeyPair.publicKeyFromPem(kasInfo.PublicKey);
             byte[] symmetricKey = ECKeyPair.computeECDHKey(kasPubKey, keyPair.getPrivateKey());

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ECKeyPairTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ECKeyPairTest.java
@@ -63,7 +63,7 @@ public class ECKeyPairTest {
         byte[] compressedKey2 = ECKeyPair.compressECPublickey(keyPairA.publicKeyInPEMFormat());
         assertArrayEquals(compressedKey1, compressedKey2);
 
-        String publicKey = ECKeyPair.publicKeyFromECPoint(compressedKey1, SECP256R1.curveName);
+        String publicKey = ECKeyPair.publicKeyFromECPoint(compressedKey1, SECP256R1.getCurveName());
         assertEquals(keyPairA.publicKeyInPEMFormat(), publicKey);
 
         ECKeyPair keyPairB = new ECKeyPair();

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ECKeyPairTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ECKeyPairTest.java
@@ -12,6 +12,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 import java.util.Base64;
 
+import static io.opentdf.platform.sdk.NanoTDFType.ECCurve.SECP256R1;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -63,8 +64,7 @@ public class ECKeyPairTest {
         byte[] compressedKey2 = ECKeyPair.compressECPublickey(keyPairA.publicKeyInPEMFormat());
         assertArrayEquals(compressedKey1, compressedKey2);
 
-        String publicKey = ECKeyPair.publicKeyFromECPoint(compressedKey1,
-                ECKeyPair.NanoTDFECCurve.SECP256R1.toString());
+        String publicKey = ECKeyPair.publicKeyFromECPoint(compressedKey1, SECP256R1.curveName);
         assertEquals(keyPairA.publicKeyInPEMFormat(), publicKey);
 
         ECKeyPair keyPairB = new ECKeyPair();
@@ -147,7 +147,7 @@ public class ECKeyPairTest {
         assertEquals(encodeECPoint, "Al3vx59pBnP8tRxuUFw18aK9ym6rFrxZRhpVQytUQ+Kg");
 
         String publicKey = ECKeyPair.publicKeyFromECPoint(ecPoint,
-                ECKeyPair.NanoTDFECCurve.SECP256R1.toString());
+                SECP256R1.name());
         assertArrayEquals(ECKeys.sdkPublicKey.toCharArray(), publicKey.toCharArray());
     }
 
@@ -155,9 +155,8 @@ public class ECKeyPairTest {
     void testECDSA() {
 
         String plainText = "Virtru!";
-        for (ECKeyPair.NanoTDFECCurve curve: ECKeyPair.NanoTDFECCurve.values()) {
-
-            ECKeyPair keyPair = new ECKeyPair(curve.toString(), ECKeyPair.ECAlgorithm.ECDSA);
+        for (var curve: NanoTDFType.ECCurve.values()) {
+            ECKeyPair keyPair = new ECKeyPair(curve.name(), ECKeyPair.ECAlgorithm.ECDSA);
             byte[] signature = ECKeyPair.computeECDSASig(plainText.getBytes(), keyPair.getPrivateKey());
             boolean verify = ECKeyPair.verifyECDSAig(plainText.getBytes(), signature, keyPair.getPublicKey());
             assertEquals(verify, true);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ECKeyPairTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ECKeyPairTest.java
@@ -47,8 +47,7 @@ public class ECKeyPairTest {
         public static final String salt = "L1L";
     }
     @Test
-    void ecPublicKeyInPemformat() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException,
-            IOException, NoSuchProviderException, InvalidKeySpecException, CertificateException, InvalidKeyException {
+    void ecPublicKeyInPemformat() {
         ECKeyPair keyPairA = new ECKeyPair();
 
         String keypairAPubicKey = keyPairA.publicKeyInPEMFormat();
@@ -156,7 +155,7 @@ public class ECKeyPairTest {
 
         String plainText = "Virtru!";
         for (var curve: NanoTDFType.ECCurve.values()) {
-            ECKeyPair keyPair = new ECKeyPair(curve.name(), ECKeyPair.ECAlgorithm.ECDSA);
+            ECKeyPair keyPair = new ECKeyPair(curve, ECKeyPair.ECAlgorithm.ECDSA);
             byte[] signature = ECKeyPair.computeECDSASig(plainText.getBytes(), keyPair.getPrivateKey());
             boolean verify = ECKeyPair.verifyECDSAig(plainText.getBytes(), signature, keyPair.getPublicKey());
             assertEquals(verify, true);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
@@ -47,7 +47,7 @@ class HeaderTest {
         ECCMode mode = new ECCMode((byte) 1); // Initialize the ECCMode object
         header.setECCMode(mode); // Set the ECCMode object
 
-        int keySize = mode.getCurve().keySize;
+        int keySize = mode.getCurve().compressedPubKeySize;
         byte[] key = new byte[keySize]; // Ensure the key size is correct
         header.setEphemeralKey(key);
         assertArrayEquals(key, header.getEphemeralKey());

--- a/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
@@ -47,7 +47,7 @@ class HeaderTest {
         ECCMode mode = new ECCMode((byte) 1); // Initialize the ECCMode object
         header.setECCMode(mode); // Set the ECCMode object
 
-        int keySize = mode.getEllipticCurveType().keySize;
+        int keySize = mode.getCurve().keySize;
         byte[] key = new byte[keySize]; // Ensure the key size is correct
         header.setEphemeralKey(key);
         assertArrayEquals(key, header.getEphemeralKey());

--- a/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
@@ -47,7 +47,7 @@ class HeaderTest {
         ECCMode mode = new ECCMode((byte) 1); // Initialize the ECCMode object
         header.setECCMode(mode); // Set the ECCMode object
 
-        int keySize = mode.getCurve().compressedPubKeySize;
+        int keySize = mode.getCurve().getCompressedPubKeySize();
         byte[] key = new byte[keySize]; // Ensure the key size is correct
         header.setEphemeralKey(key);
         assertArrayEquals(key, header.getEphemeralKey());

--- a/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/HeaderTest.java
@@ -47,7 +47,7 @@ class HeaderTest {
         ECCMode mode = new ECCMode((byte) 1); // Initialize the ECCMode object
         header.setECCMode(mode); // Set the ECCMode object
 
-        int keySize = ECCMode.getECCompressedPubKeySize(mode.getEllipticCurveType());
+        int keySize = mode.getEllipticCurveType().keySize;
         byte[] key = new byte[keySize]; // Ensure the key size is correct
         header.setEphemeralKey(key);
         assertArrayEquals(key, header.getEphemeralKey());

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
@@ -169,7 +169,7 @@ public class NanoTDFHeaderTest {
                 header2.setPolicyInfo(policyInfo);
 
                 int sizeToRead = policyInfo.getTotalSize();
-                int compressedPubKeySize = header2.getECCMode().getCurve().compressedPubKeySize;
+                int compressedPubKeySize = header2.getECCMode().getCurve().getCompressedPubKeySize();
                 byte[] ephemeralKey = new byte[compressedPubKeySize]; // size of compressed public key
                 System.arraycopy(remainingBytesArray, sizeToRead, ephemeralKey, 0, ephemeralKey.length);
                 header2.setEphemeralKey(ephemeralKey);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
@@ -169,7 +169,7 @@ public class NanoTDFHeaderTest {
                 header2.setPolicyInfo(policyInfo);
 
                 int sizeToRead = policyInfo.getTotalSize();
-                int compressedPubKeySize = header2.getECCMode().getCurve().keySize;
+                int compressedPubKeySize = header2.getECCMode().getCurve().compressedPubKeySize;
                 byte[] ephemeralKey = new byte[compressedPubKeySize]; // size of compressed public key
                 System.arraycopy(remainingBytesArray, sizeToRead, ephemeralKey, 0, ephemeralKey.length);
                 header2.setEphemeralKey(ephemeralKey);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
@@ -201,11 +201,11 @@ public class NanoTDFHeaderTest {
                 byte[] tag = new byte[tagSize];
 
                 ECCMode eccMode = new ECCMode((byte) 0x0); // no ecdsa binding and 'secp256r1'
-                ECKeyPair sdkECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType().curveName, ECKeyPair.ECAlgorithm.ECDH);
+                ECKeyPair sdkECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType(), ECKeyPair.ECAlgorithm.ECDH);
                 String sdkPrivateKeyForEncrypt = sdkECKeyPair.privateKeyInPEMFormat();
                 String sdkPublicKeyForEncrypt = sdkECKeyPair.publicKeyInPEMFormat();
 
-                ECKeyPair kasECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType().curveName, ECKeyPair.ECAlgorithm.ECDH);
+                ECKeyPair kasECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType(), ECKeyPair.ECAlgorithm.ECDH);
                 String kasPublicKey = kasECKeyPair.publicKeyInPEMFormat();
                 // Encrypt
                 Header header = new Header();

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
@@ -169,7 +169,7 @@ public class NanoTDFHeaderTest {
                 header2.setPolicyInfo(policyInfo);
 
                 int sizeToRead = policyInfo.getTotalSize();
-                int compressedPubKeySize = header2.getECCMode().getEllipticCurveType().keySize;
+                int compressedPubKeySize = header2.getECCMode().getCurve().keySize;
                 byte[] ephemeralKey = new byte[compressedPubKeySize]; // size of compressed public key
                 System.arraycopy(remainingBytesArray, sizeToRead, ephemeralKey, 0, ephemeralKey.length);
                 header2.setEphemeralKey(ephemeralKey);
@@ -201,11 +201,11 @@ public class NanoTDFHeaderTest {
                 byte[] tag = new byte[tagSize];
 
                 ECCMode eccMode = new ECCMode((byte) 0x0); // no ecdsa binding and 'secp256r1'
-                ECKeyPair sdkECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType(), ECKeyPair.ECAlgorithm.ECDH);
+                ECKeyPair sdkECKeyPair = new ECKeyPair(eccMode.getCurve(), ECKeyPair.ECAlgorithm.ECDH);
                 String sdkPrivateKeyForEncrypt = sdkECKeyPair.privateKeyInPEMFormat();
                 String sdkPublicKeyForEncrypt = sdkECKeyPair.publicKeyInPEMFormat();
 
-                ECKeyPair kasECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType(), ECKeyPair.ECAlgorithm.ECDH);
+                ECKeyPair kasECKeyPair = new ECKeyPair(eccMode.getCurve(), ECKeyPair.ECAlgorithm.ECDH);
                 String kasPublicKey = kasECKeyPair.publicKeyInPEMFormat();
                 // Encrypt
                 Header header = new Header();

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFHeaderTest.java
@@ -104,7 +104,7 @@ public class NanoTDFHeaderTest {
                 header.setECCMode(eccMode);
 
                 SymmetricAndPayloadConfig payloadConfig = new SymmetricAndPayloadConfig((byte) 0x0); // no signature and
-                                                                                                     // AES_256_GCM_64_TAG
+                // AES_256_GCM_64_TAG
                 header.setPayloadConfig(payloadConfig);
 
                 PolicyInfo policyInfo = new PolicyInfo();
@@ -114,8 +114,7 @@ public class NanoTDFHeaderTest {
                 header.setPolicyInfo(policyInfo);
                 header.setEphemeralKey(compressedPubKey);
 
-                int headerSize = header.getTotalSize();
-                headerSize = header.writeIntoBuffer(ByteBuffer.wrap(headerData));
+                int headerSize = header.writeIntoBuffer(ByteBuffer.wrap(headerData));
                 assertEquals(headerData.length, headerSize);
                 assertTrue(Arrays.equals(headerData, expectedHeader));
         }
@@ -170,8 +169,7 @@ public class NanoTDFHeaderTest {
                 header2.setPolicyInfo(policyInfo);
 
                 int sizeToRead = policyInfo.getTotalSize();
-                int compressedPubKeySize = ECCMode
-                                .getECCompressedPubKeySize(header2.getECCMode().getEllipticCurveType());
+                int compressedPubKeySize = header2.getECCMode().getEllipticCurveType().keySize;
                 byte[] ephemeralKey = new byte[compressedPubKeySize]; // size of compressed public key
                 System.arraycopy(remainingBytesArray, sizeToRead, ephemeralKey, 0, ephemeralKey.length);
                 header2.setEphemeralKey(ephemeralKey);
@@ -203,11 +201,11 @@ public class NanoTDFHeaderTest {
                 byte[] tag = new byte[tagSize];
 
                 ECCMode eccMode = new ECCMode((byte) 0x0); // no ecdsa binding and 'secp256r1'
-                ECKeyPair sdkECKeyPair = new ECKeyPair(eccMode.getCurveName(), ECKeyPair.ECAlgorithm.ECDH);
+                ECKeyPair sdkECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType().curveName, ECKeyPair.ECAlgorithm.ECDH);
                 String sdkPrivateKeyForEncrypt = sdkECKeyPair.privateKeyInPEMFormat();
                 String sdkPublicKeyForEncrypt = sdkECKeyPair.publicKeyInPEMFormat();
 
-                ECKeyPair kasECKeyPair = new ECKeyPair(eccMode.getCurveName(), ECKeyPair.ECAlgorithm.ECDH);
+                ECKeyPair kasECKeyPair = new ECKeyPair(eccMode.getEllipticCurveType().curveName, ECKeyPair.ECAlgorithm.ECDH);
                 String kasPublicKey = kasECKeyPair.publicKeyInPEMFormat();
                 // Encrypt
                 Header header = new Header();

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
@@ -99,7 +99,7 @@ public class NanoTDFTest {
             Header nTDFHeader = new Header(ByteBuffer.wrap(headerAsBytes));
             byte[] ephemeralKey = nTDFHeader.getEphemeralKey();
 
-            String publicKeyAsPem = ECKeyPair.publicKeyFromECPoint(ephemeralKey, nTDFHeader.getECCMode().getCurve().curveName);
+            String publicKeyAsPem = ECKeyPair.publicKeyFromECPoint(ephemeralKey, nTDFHeader.getECCMode().getCurve().getCurveName());
 
             // Generate symmetric key
             byte[] symmetricKey = ECKeyPair.computeECDHKey(ECKeyPair.publicKeyFromPem(publicKeyAsPem),
@@ -341,6 +341,7 @@ public class NanoTDFTest {
         kasInfo.URL = sampleKasUrl;
         kasInfo.PublicKey = kasPublicKey;
         kasInfo.KID = KID;
+        kasInfo.Algorithm = "ec:secp256r1";
         kasInfos.add(kasInfo);
 
         Config.NanoTDFConfig config = Config.newNanoTDFConfig(

--- a/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/NanoTDFTest.java
@@ -98,7 +98,7 @@ public class NanoTDFTest {
             Header nTDFHeader = new Header(ByteBuffer.wrap(headerAsBytes));
             byte[] ephemeralKey = nTDFHeader.getEphemeralKey();
 
-            String publicKeyAsPem = ECKeyPair.publicKeyFromECPoint(ephemeralKey, nTDFHeader.getECCMode().getCurveName());
+            String publicKeyAsPem = ECKeyPair.publicKeyFromECPoint(ephemeralKey, nTDFHeader.getECCMode().getEllipticCurveType().curveName);
 
             // Generate symmetric key
             byte[] symmetricKey = ECKeyPair.computeECDHKey(ECKeyPair.publicKeyFromPem(publicKeyAsPem),

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -123,7 +123,7 @@ public class TDFTest {
             if (i % 2 == 0) {
                 keypairs.add(CryptoUtils.generateRSAKeypair());
             } else {
-                keypairs.add(CryptoUtils.generateECKeypair(NanoTDFType.ECCurve.SECP256R1.curveName));
+                keypairs.add(CryptoUtils.generateECKeypair(NanoTDFType.ECCurve.SECP256R1.getCurveName()));
             }
         }
 

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TDFTest.java
@@ -123,7 +123,7 @@ public class TDFTest {
             if (i % 2 == 0) {
                 keypairs.add(CryptoUtils.generateRSAKeypair());
             } else {
-                keypairs.add(CryptoUtils.generateECKeypair(KeyType.EC256Key.getCurveName()));
+                keypairs.add(CryptoUtils.generateECKeypair(NanoTDFType.ECCurve.SECP256R1.curveName));
             }
         }
 


### PR DESCRIPTION
Instead of taking what's in the config use what's in the key since it's actually what has been used
to actually do the cryptography. Also some refactoring to simplify how we get key metadata.

One thing that I noticed during was that `compressedPublicKeySize` is less than `keySize`. I'm not
sure if this is correct but if it is I'd like to find out so I can comment why that's the case.
