### PR TITLE
fix(sdk): upgrade the platform protocol code

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -15,7 +15,7 @@
         <kotlin.version>2.1.0</kotlin.version>
         <connect.version>0.7.2</connect.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <platform.branch>protocol/go/v0.3.0</platform.branch>
+        <platform.branch>protocol/go/v0.5.0</platform.branch>
     </properties>
     <dependencies>
         <!-- Logging Dependencies -->


### PR DESCRIPTION
In gateway we are seeing an error like
```
Caused by: com.google.protobuf.InvalidProtocolBufferException: While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length
```
when fetching attributes. [`v2.6.2` of platform contains `v0.5.0` of `protocol/go`](https://github.com/virtru-corp/data-security-platform/blob/v2.6.2/go.mod#L34) and there are changes between the two versions in the attributes. This should at least be safe.

