### PR TITLE
fix(sdk): add methods to examine Manifest and Policy

### DIFF
--- a/examples/src/main/java/io/opentdf/platform/GetManifestInformation.java
+++ b/examples/src/main/java/io/opentdf/platform/GetManifestInformation.java
@@ -1,0 +1,23 @@
+package io.opentdf.platform;
+
+import io.opentdf.platform.sdk.Manifest;
+import io.opentdf.platform.sdk.PolicyObject;
+import io.opentdf.platform.sdk.SDK;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class GetManifestInformation {
+    public static void main(String[] args) throws IOException {
+        FileChannel tdfStream = FileChannel.open(Path.of(args[0]), StandardOpenOption.READ);
+
+        Manifest manifest = SDK.readManifest(tdfStream);
+        System.out.println("loaded a tdf with key access type: " + manifest.encryptionInformation.keyAccessType);
+
+        PolicyObject policyObject = SDK.decodePolicyObject(manifest);
+        System.out.println("the policy has uuid: " + policyObject.uuid);
+    }
+}
+

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Manifest.java
@@ -27,7 +27,6 @@ import org.apache.commons.codec.binary.Hex;
 import org.erdtman.jcs.JsonCanonicalizer;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -500,8 +499,8 @@ public class Manifest {
     public EncryptionInformation encryptionInformation;
     public Payload payload;
     public List<Assertion> assertions = new ArrayList<>();
-    protected static Manifest readManifest(Reader reader) {
-        Manifest result = gson.fromJson(reader, Manifest.class);
+    protected static Manifest readManifest(String manifestJson) {
+        Manifest result = gson.fromJson(manifestJson, Manifest.class);
         if (result.assertions == null) {
             result.assertions = new ArrayList<>();
         }
@@ -539,8 +538,7 @@ public class Manifest {
         return result;
     }
 
-    static PolicyObject readPolicyObject(Reader reader) {
-        var manifest = readManifest(reader);
+    static PolicyObject decodePolicyObject(Manifest manifest) {
         var policyBase64 = manifest.encryptionInformation.policy;
         var policyBytes = Base64.getDecoder().decode(policyBase64);
         var policyJson = new String(policyBytes, StandardCharsets.UTF_8);

--- a/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/SDK.java
@@ -145,6 +145,30 @@ public class SDK implements AutoCloseable {
                 && entries.stream().anyMatch(e -> "0.payload".equals(e.getName()));
     }
 
+    /**
+     * Reads the manifest without decrypting the TDF
+     * @param tdfBytes A SeekableByteChannel containing the TDF data
+     * @return
+     * @throws SDKException
+     * @throws IOException
+     */
+    public static Manifest readManifest(SeekableByteChannel tdfBytes) throws SDKException, IOException {
+        TDFReader reader = new TDFReader(tdfBytes);
+        String manifestJson = reader.manifest();
+        return Manifest.readManifest(manifestJson);
+    }
+
+    /**
+     * Decodes a PolicyObject from the manifest. Use {@link SDK#decodePolicyObject(Manifest)}
+     * to get the manifest from a TDF.
+     * @param manifest
+     * @return
+     * @throws SDKException
+     */
+    public static PolicyObject decodePolicyObject(Manifest manifest) throws SDKException {
+        return Manifest.decodePolicyObject(manifest);
+    }
+
     public String getPlatformUrl() {
         return platformUrl;
     }

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDF.java
@@ -607,7 +607,7 @@ class TDF {
         TDFReader tdfReader = new TDFReader(tdf);
         String manifestJson = tdfReader.manifest();
         // use Manifest.readManifest in order to validate the Manifest input
-        Manifest manifest = Manifest.readManifest(new StringReader(manifestJson));
+        Manifest manifest = Manifest.readManifest(manifestJson);
         byte[] payloadKey = new byte[GCM_KEY_SIZE];
         String unencryptedMetadata = null;
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/TDFReader.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/TDFReader.java
@@ -64,10 +64,8 @@ public class TDFReader {
     }
 
     PolicyObject readPolicyObject() {
-        try (var reader = new BufferedReader(new InputStreamReader(manifestEntry.getData()))){
-            return Manifest.readPolicyObject(reader);
-        } catch (IOException e) {
-            throw new SDKException("error reading policy object", e);
-        }
+        String manifestJson = manifest();
+        Manifest manifest = Manifest.readManifest(manifestJson);
+        return Manifest.decodePolicyObject(manifest);
     }
 }

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ManifestTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ManifestTest.java
@@ -62,7 +62,7 @@ public class ManifestTest {
                 "  }\n" +
                 "}";
 
-        Manifest manifest = Manifest.readManifest(new StringReader(kManifestJsonFromTDF));
+        Manifest manifest = Manifest.readManifest(kManifestJsonFromTDF);
 
         // Test payload
         assertEquals(manifest.payload.url, "0.payload");
@@ -85,7 +85,7 @@ public class ManifestTest {
         assertEquals(manifest.encryptionInformation.integrityInformation.segments.get(0).segmentSize, 1048576);
 
         var serialized = Manifest.toJson(manifest);
-        var deserializedAgain = Manifest.readManifest(new StringReader(serialized));
+        var deserializedAgain = Manifest.readManifest(serialized);
 
         assertEquals(manifest, deserializedAgain, "something changed when we deserialized -> serialized -> deserialized");
     }
@@ -140,7 +140,7 @@ public class ManifestTest {
                 "   \"assertions\": null\n"+
                 "}";
 
-        Manifest manifest = Manifest.readManifest(new StringReader(kManifestJsonFromTDF));
+        Manifest manifest = Manifest.readManifest(kManifestJsonFromTDF);
 
         // Test payload for sanity check
         assertEquals(manifest.payload.url, "0.payload");
@@ -155,7 +155,8 @@ public class ManifestTest {
         final Manifest manifest;
         try (var mStream = getClass().getResourceAsStream("/io.opentdf.platform.sdk.TestData/manifest-with-object-statement-value.json")) {
             assert mStream != null;
-            manifest = Manifest.readManifest(new InputStreamReader(mStream)) ;
+            var manifestJson = new String(mStream.readAllBytes());
+            manifest = Manifest.readManifest(manifestJson);
         }
 
         assertThat(manifest.assertions).hasSize(2);

--- a/sdk/src/test/java/io/opentdf/platform/sdk/SDKTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/SDKTest.java
@@ -78,6 +78,21 @@ class SDKTest {
     }
 
     @Test
+    void testExaminingManifest() throws IOException {
+        try (var tdfStream = SDKTest.class.getClassLoader().getResourceAsStream("sample.txt.tdf")) {
+            assertThat(tdfStream)
+                    .withFailMessage("sample.txt.tdf not found in classpath")
+                    .isNotNull();
+            var manifest = SDK.readManifest(new SeekableInMemoryByteChannel(tdfStream.readAllBytes()));
+            assertThat(manifest).isNotNull();
+            assertThat(manifest.encryptionInformation.integrityInformation.encryptedSegmentSizeDefault)
+                    .isEqualTo(1048604);
+            var policyObject = SDK.decodePolicyObject(manifest);
+            assertThat(policyObject.uuid).isEqualTo("98bb8a81-5217-4a31-8852-932d29d71aac");
+        }
+    }
+
+    @Test
     void testReadingRandomBytes() {
         var tdf = new byte[2023];
         new Random().nextBytes(tdf);


### PR DESCRIPTION
These capabilities were removed during a previous refactoring

Also change `Manifest.readManfest` to take in a `String` since that's the
only way it's ever used.