### PR TITLE
chore: rename sslcontext-kickstart to ayza and bump it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
         <log4j.version>2.20.0</log4j.version>
         <grpc.version>1.68.0</grpc.version>
         <protobuf.version>4.29.2</protobuf.version>
-        <sslcontext.version>8.3.5</sslcontext.version>
+        <bouncycastle.version>1.82</bouncycastle.version>
+        <ayza.version>10.0.0</ayza.version>
         <!-- JaCoCo Properties -->
         <jacoco.version>0.8.13</jacoco.version>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -78,8 +79,8 @@
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-pem</artifactId>
-                <version>${sslcontext.version}</version>
+                <artifactId>ayza-for-pem</artifactId>
+                <version>${ayza.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -89,8 +90,8 @@
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart</artifactId>
-                <version>${sslcontext.version}</version>
+                <artifactId>ayza</artifactId>
+                <version>${ayza.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -100,8 +101,8 @@
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-netty</artifactId>
-                <version>${sslcontext.version}</version>
+                <artifactId>ayza-for-netty</artifactId>
+                <version>${ayza.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -144,6 +145,16 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
                 <version>2.1.20</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -33,15 +33,15 @@
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart</artifactId>
+            <artifactId>ayza</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-netty</artifactId>
+            <artifactId>ayza-for-netty</artifactId>
         </dependency>
         <!-- Serialization and Deserialization Dependencies -->
         <dependency>
@@ -164,7 +164,10 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.78.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <!-- Testing Dependencies -->
         <dependency>


### PR DESCRIPTION
also make sure that we have a dependency on `bcprov-jdk18on` since we use this provider in our code

takes over this pull from the library author https://github.com/opentdf/java-sdk/pull/291