### PR TITLE
fix(ci): allow release branch scopes in PR title validation

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -49,6 +49,7 @@ jobs:
           #   - sdk: changes to sdk
           #   - tests: test only changes
           #   - examples: examples only changes
+          #   - release/v0.\d+: release-please release branch PRs
           scopes: |
             ci
             cmdline
@@ -57,6 +58,7 @@ jobs:
             sdk
             tests
             examples
+            release/v0\.\d+
 
   mavenverify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `release/v0\.\d+` regex pattern to the allowed scopes in the PR title validation workflow
- Fixes `Validate PR title` check failing on release-please PRs targeting release branches (e.g. #348, #315, #289)

Release-please uses the pattern `chore(${branch}): release ${version}` for PR titles, which produces scopes like `release/v0.13` for release branch PRs. These scopes were not in the allowed list, causing CI to fail.

## Test plan

- [x] Verify this PR's own `Validate PR title` check passes
- [ ] Confirm #348 passes after this merges (or re-run its check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request validation workflow to recognize and properly handle release automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->