### PR TITLE
feat(sdk): add ergonomic Resource constructors for authorization

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/Resources.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Resources.java
@@ -1,0 +1,71 @@
+package io.opentdf.platform.sdk;
+
+import io.opentdf.platform.authorization.v2.Resource;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Convenience constructors for {@link Resource}, mirroring the Go SDK helpers
+ * in {@code authorization/v2.ForAttributeValues}, {@code ForRegisteredResourceValueFqn}.
+ *
+ * <p>Each method builds the full {@code Resource} proto so callers avoid
+ * deeply nested builder chains.
+ *
+ * <pre>{@code
+ * // Before
+ * Resource.newBuilder()
+ *     .setAttributeValues(
+ *         Resource.AttributeValues.newBuilder()
+ *             .addFqns("https://example.com/attr/department/value/finance"))
+ *     .build();
+ *
+ * // After
+ * Resources.forAttributeValues("https://example.com/attr/department/value/finance");
+ * }</pre>
+ */
+public final class Resources {
+
+    private Resources() {}
+
+    /**
+     * Returns a Resource containing the given attribute value FQNs.
+     * This is the most common Resource variant, used when authorizing against
+     * attribute values attached to data (e.g. those on a TDF).
+     *
+     * @param fqns one or more fully qualified attribute value names
+     * @return a fully built {@link Resource} with the {@code attribute_values} oneof set
+     * @throws NullPointerException if {@code fqns} or any element is null
+     * @throws IllegalArgumentException if {@code fqns} is empty
+     */
+    public static Resource forAttributeValues(String... fqns) {
+        Objects.requireNonNull(fqns, "fqns must not be null");
+        if (fqns.length == 0) {
+            throw new IllegalArgumentException("fqns must not be empty");
+        }
+        for (String fqn : fqns) {
+            Objects.requireNonNull(fqn, "individual fqn must not be null");
+        }
+        return Resource.newBuilder()
+                .setAttributeValues(
+                        Resource.AttributeValues.newBuilder()
+                                .addAllFqns(Arrays.asList(fqns))
+                                .build())
+                .build();
+    }
+
+    /**
+     * Returns a Resource that references a single registered resource value
+     * by its fully qualified name, as stored in platform policy.
+     *
+     * @param fqn the fully qualified name of the registered resource value
+     * @return a fully built {@link Resource} with the {@code registered_resource_value_fqn} oneof set
+     * @throws NullPointerException if {@code fqn} is null
+     */
+    public static Resource forRegisteredResourceValueFqn(String fqn) {
+        Objects.requireNonNull(fqn, "fqn must not be null");
+        return Resource.newBuilder()
+                .setRegisteredResourceValueFqn(fqn)
+                .build();
+    }
+}

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Resources.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Resources.java
@@ -6,8 +6,8 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * Convenience constructors for {@link Resource}, mirroring the Go SDK helpers
- * in {@code authorization/v2.ForAttributeValues}, {@code ForRegisteredResourceValueFqn}.
+ * Convenience constructors for {@link Resource}, analogous to the
+ * {@link EntityIdentifiers} helpers for {@link io.opentdf.platform.authorization.v2.EntityIdentifier}.
  *
  * <p>Each method builds the full {@code Resource} proto so callers avoid
  * deeply nested builder chains.

--- a/sdk/src/test/java/io/opentdf/platform/sdk/ResourcesTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/ResourcesTest.java
@@ -1,0 +1,63 @@
+package io.opentdf.platform.sdk;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentdf.platform.authorization.v2.Resource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ResourcesTest {
+
+    @Test
+    void forAttributeValues_single() {
+        String fqn = "https://example.com/attr/department/value/finance";
+        Resource r = Resources.forAttributeValues(fqn);
+
+        assertEquals(Resource.ResourceCase.ATTRIBUTE_VALUES, r.getResourceCase());
+        assertEquals(1, r.getAttributeValues().getFqnsCount());
+        assertEquals(fqn, r.getAttributeValues().getFqns(0));
+    }
+
+    @Test
+    void forAttributeValues_multiple() {
+        String fqn1 = "https://example.com/attr/department/value/finance";
+        String fqn2 = "https://example.com/attr/level/value/public";
+        Resource r = Resources.forAttributeValues(fqn1, fqn2);
+
+        assertEquals(Resource.ResourceCase.ATTRIBUTE_VALUES, r.getResourceCase());
+        assertEquals(2, r.getAttributeValues().getFqnsCount());
+        assertEquals(fqn1, r.getAttributeValues().getFqns(0));
+        assertEquals(fqn2, r.getAttributeValues().getFqns(1));
+    }
+
+    @Test
+    void forAttributeValues_emptyStringFqn() {
+        Resource r = Resources.forAttributeValues("");
+
+        assertEquals(Resource.ResourceCase.ATTRIBUTE_VALUES, r.getResourceCase());
+        assertEquals(1, r.getAttributeValues().getFqnsCount());
+        assertEquals("", r.getAttributeValues().getFqns(0));
+    }
+
+    @Test
+    void forAttributeValues_emptyArrayThrows() {
+        assertThrows(IllegalArgumentException.class, () -> Resources.forAttributeValues());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"https://example.com/attr/department/value/finance", ""})
+    void forRegisteredResourceValueFqn(String fqn) {
+        Resource r = Resources.forRegisteredResourceValueFqn(fqn);
+
+        assertEquals(Resource.ResourceCase.REGISTERED_RESOURCE_VALUE_FQN, r.getResourceCase());
+        assertEquals(fqn, r.getRegisteredResourceValueFqn());
+    }
+
+    @Test
+    void nullInputsThrow() {
+        assertThrows(NullPointerException.class, () -> Resources.forAttributeValues((String[]) null));
+        assertThrows(NullPointerException.class, () -> Resources.forAttributeValues("valid", null));
+        assertThrows(NullPointerException.class, () -> Resources.forRegisteredResourceValueFqn(null));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Resources` utility class with `forAttributeValues(String... fqns)` and `forRegisteredResourceValueFqn(String fqn)` helpers
- Follows the same pattern as `EntityIdentifiers` from #346
- Reduces verbose nested protobuf builder chains to single-line calls

**Before:**
```java
Resource.newBuilder()
    .setAttributeValues(
        Resource.AttributeValues.newBuilder()
            .addFqns("https://example.com/attr/department/value/finance"))
    .build();
```

**After:**
```java
Resources.forAttributeValues("https://example.com/attr/department/value/finance");
```

**Example — GetDecision authorization call:**
```java
import io.opentdf.platform.sdk.EntityIdentifiers;
import io.opentdf.platform.sdk.Resources;

GetDecisionRequest request = GetDecisionRequest.newBuilder()
    .setEntityIdentifier(EntityIdentifiers.forEmail("user@company.com"))
    .setAction(Action.newBuilder().setName("decrypt"))
    .setResource(Resources.forAttributeValues(
        "https://company.com/attr/clearance/value/confidential",
        "https://company.com/attr/department/value/finance"))
    .build();

GetDecisionResponse resp = sdk.getServices()
    .authorization()
    .getDecision(request)
    .get();
```

## Test plan

- [x] Unit tests for `forAttributeValues` (single, multiple, empty-string FQN, empty array throws)
- [x] Unit tests for `forRegisteredResourceValueFqn` (valid + empty string)
- [x] Null safety tests (null array, null element, null fqn all throw NPE)
- [x] Full SDK test suite passes (157 tests, 0 failures)
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)