### PR TITLE
feat(sdk): add shorthand enum constants for policy types

### DIFF
--- a/examples/src/main/java/io/opentdf/platform/CreateAttribute.java
+++ b/examples/src/main/java/io/opentdf/platform/CreateAttribute.java
@@ -1,12 +1,12 @@
 package io.opentdf.platform;
 
 import com.connectrpc.ResponseMessageKt;
-import io.opentdf.platform.policy.AttributeRuleTypeEnum;
 import io.opentdf.platform.policy.Namespace;
 import io.opentdf.platform.policy.attributes.CreateAttributeRequest;
 import io.opentdf.platform.policy.attributes.CreateAttributeResponse;
 import io.opentdf.platform.policy.namespaces.GetNamespaceRequest;
 import io.opentdf.platform.sdk.*;
+import static io.opentdf.platform.sdk.PolicyEnums.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -51,9 +51,7 @@ public class CreateAttribute {
           CreateAttributeRequest.newBuilder()
               .setNamespaceId(namespace.getId())
               .setName("test-attribute")
-              .setRule(
-                  AttributeRuleTypeEnum.forNumber(
-                      AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF_VALUE))
+              .setRule(RULE_ALL_OF)
               .addAllValues(Arrays.asList("test1", "test2"))
               .build();
 

--- a/examples/src/main/java/io/opentdf/platform/CreateSubjectConditionSet.java
+++ b/examples/src/main/java/io/opentdf/platform/CreateSubjectConditionSet.java
@@ -2,11 +2,10 @@ package io.opentdf.platform;
 
 import com.connectrpc.ResponseMessageKt;
 import io.opentdf.platform.policy.Condition;
-import io.opentdf.platform.policy.ConditionBooleanTypeEnum;
 import io.opentdf.platform.policy.ConditionGroup;
 import io.opentdf.platform.policy.SubjectConditionSet;
-import io.opentdf.platform.policy.SubjectMappingOperatorEnum;
 import io.opentdf.platform.policy.SubjectSet;
+import static io.opentdf.platform.sdk.PolicyEnums.*;
 import io.opentdf.platform.policy.subjectmapping.CreateSubjectConditionSetRequest;
 import io.opentdf.platform.policy.subjectmapping.CreateSubjectConditionSetResponse;
 import io.opentdf.platform.policy.subjectmapping.SubjectConditionSetCreate;
@@ -39,12 +38,11 @@ public class CreateSubjectConditionSet {
           SubjectSet.newBuilder()
               .addConditionGroups(
                   ConditionGroup.newBuilder()
-                      .setBooleanOperator(ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_AND)
+                      .setBooleanOperator(BOOLEAN_AND)
                       .addConditions(
                           Condition.newBuilder()
                               .setSubjectExternalSelectorValue(".myfield")
-                              .setOperator(
-                                  SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN)
+                              .setOperator(OPERATOR_IN)
                               .addSubjectExternalValues("myvalue")));
 
       CreateSubjectConditionSetRequest createSubjectConditionSetRequest =

--- a/examples/src/main/java/io/opentdf/platform/CreateSubjectMapping.java
+++ b/examples/src/main/java/io/opentdf/platform/CreateSubjectMapping.java
@@ -4,13 +4,12 @@ import com.connectrpc.ResponseMessageKt;
 import io.opentdf.platform.policy.Action;
 import io.opentdf.platform.policy.Attribute;
 import io.opentdf.platform.policy.Condition;
-import io.opentdf.platform.policy.ConditionBooleanTypeEnum;
 import io.opentdf.platform.policy.ConditionGroup;
 import io.opentdf.platform.policy.Namespace;
 import io.opentdf.platform.policy.SubjectConditionSet;
 import io.opentdf.platform.policy.SubjectMapping;
-import io.opentdf.platform.policy.SubjectMappingOperatorEnum;
 import io.opentdf.platform.policy.SubjectSet;
+import static io.opentdf.platform.sdk.PolicyEnums.*;
 import io.opentdf.platform.policy.attributes.GetAttributeRequest;
 import io.opentdf.platform.policy.namespaces.GetNamespaceRequest;
 import io.opentdf.platform.policy.subjectmapping.CreateSubjectConditionSetRequest;
@@ -100,14 +99,11 @@ public class CreateSubjectMapping {
                           SubjectSet.newBuilder()
                               .addConditionGroups(
                                   ConditionGroup.newBuilder()
-                                      .setBooleanOperator(
-                                          ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_AND)
+                                      .setBooleanOperator(BOOLEAN_AND)
                                       .addConditions(
                                           Condition.newBuilder()
                                               .setSubjectExternalSelectorValue(".myfield")
-                                              .setOperator(
-                                                  SubjectMappingOperatorEnum
-                                                      .SUBJECT_MAPPING_OPERATOR_ENUM_IN)
+                                              .setOperator(OPERATOR_IN)
                                               .addSubjectExternalValues("myvalue")))))
               .build();
 

--- a/sdk/src/main/java/io/opentdf/platform/sdk/PolicyEnums.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/PolicyEnums.java
@@ -1,0 +1,69 @@
+package io.opentdf.platform.sdk;
+
+import io.opentdf.platform.common.ActiveStateEnum;
+import io.opentdf.platform.policy.AttributeRuleTypeEnum;
+import io.opentdf.platform.policy.ConditionBooleanTypeEnum;
+import io.opentdf.platform.policy.SubjectMappingOperatorEnum;
+
+/**
+ * Shorthand constants for commonly used policy enum values.
+ *
+ * <p>These aliases provide a more readable alternative to the verbose protobuf
+ * enum names. Use them anywhere the corresponding enum type is accepted.
+ *
+ * <pre>{@code
+ * // Before
+ * Condition.newBuilder()
+ *     .setOperator(SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN);
+ *
+ * // After (with static import)
+ * import static io.opentdf.platform.sdk.PolicyEnums.*;
+ * Condition.newBuilder()
+ *     .setOperator(OPERATOR_IN);
+ * }</pre>
+ */
+public final class PolicyEnums {
+
+    private PolicyEnums() {}
+
+    // --- Subject Mapping Operators ---
+
+    public static final SubjectMappingOperatorEnum OPERATOR_IN =
+            SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN;
+
+    public static final SubjectMappingOperatorEnum OPERATOR_NOT_IN =
+            SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN;
+
+    public static final SubjectMappingOperatorEnum OPERATOR_IN_CONTAINS =
+            SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS;
+
+    // --- Condition Boolean Types ---
+
+    public static final ConditionBooleanTypeEnum BOOLEAN_AND =
+            ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_AND;
+
+    public static final ConditionBooleanTypeEnum BOOLEAN_OR =
+            ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_OR;
+
+    // --- Attribute Rule Types ---
+
+    public static final AttributeRuleTypeEnum RULE_ALL_OF =
+            AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF;
+
+    public static final AttributeRuleTypeEnum RULE_ANY_OF =
+            AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF;
+
+    public static final AttributeRuleTypeEnum RULE_HIERARCHY =
+            AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY;
+
+    // --- Active States ---
+
+    public static final ActiveStateEnum STATE_ACTIVE =
+            ActiveStateEnum.ACTIVE_STATE_ENUM_ACTIVE;
+
+    public static final ActiveStateEnum STATE_INACTIVE =
+            ActiveStateEnum.ACTIVE_STATE_ENUM_INACTIVE;
+
+    public static final ActiveStateEnum STATE_ANY =
+            ActiveStateEnum.ACTIVE_STATE_ENUM_ANY;
+}

--- a/sdk/src/test/java/io/opentdf/platform/sdk/PolicyEnumsTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/PolicyEnumsTest.java
@@ -1,0 +1,61 @@
+package io.opentdf.platform.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentdf.platform.common.ActiveStateEnum;
+import io.opentdf.platform.policy.AttributeRuleTypeEnum;
+import io.opentdf.platform.policy.ConditionBooleanTypeEnum;
+import io.opentdf.platform.policy.SubjectMappingOperatorEnum;
+import org.junit.jupiter.api.Test;
+
+class PolicyEnumsTest {
+
+    @Test
+    void operatorConstants() {
+        assertEquals(
+                SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN,
+                PolicyEnums.OPERATOR_IN);
+        assertEquals(
+                SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN,
+                PolicyEnums.OPERATOR_NOT_IN);
+        assertEquals(
+                SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS,
+                PolicyEnums.OPERATOR_IN_CONTAINS);
+    }
+
+    @Test
+    void booleanConstants() {
+        assertEquals(
+                ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_AND,
+                PolicyEnums.BOOLEAN_AND);
+        assertEquals(
+                ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_OR,
+                PolicyEnums.BOOLEAN_OR);
+    }
+
+    @Test
+    void ruleConstants() {
+        assertEquals(
+                AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF,
+                PolicyEnums.RULE_ALL_OF);
+        assertEquals(
+                AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF,
+                PolicyEnums.RULE_ANY_OF);
+        assertEquals(
+                AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY,
+                PolicyEnums.RULE_HIERARCHY);
+    }
+
+    @Test
+    void stateConstants() {
+        assertEquals(
+                ActiveStateEnum.ACTIVE_STATE_ENUM_ACTIVE,
+                PolicyEnums.STATE_ACTIVE);
+        assertEquals(
+                ActiveStateEnum.ACTIVE_STATE_ENUM_INACTIVE,
+                PolicyEnums.STATE_INACTIVE);
+        assertEquals(
+                ActiveStateEnum.ACTIVE_STATE_ENUM_ANY,
+                PolicyEnums.STATE_ANY);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PolicyEnums` utility class with readable constant aliases for verbose protobuf enum names so developers can write `PolicyEnums.OPERATOR_IN` instead of `SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN`
- Update all examples to use the new shorthand constants via static imports
- Companion to opentdf/platform#3408 (Go SDK equivalent)

### Constants added

| Shorthand | Full proto name |
|---|---|
| `OPERATOR_IN` | `SUBJECT_MAPPING_OPERATOR_ENUM_IN` |
| `OPERATOR_NOT_IN` | `SUBJECT_MAPPING_OPERATOR_ENUM_NOT_IN` |
| `OPERATOR_IN_CONTAINS` | `SUBJECT_MAPPING_OPERATOR_ENUM_IN_CONTAINS` |
| `BOOLEAN_AND` | `CONDITION_BOOLEAN_TYPE_ENUM_AND` |
| `BOOLEAN_OR` | `CONDITION_BOOLEAN_TYPE_ENUM_OR` |
| `RULE_ALL_OF` | `ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF` |
| `RULE_ANY_OF` | `ATTRIBUTE_RULE_TYPE_ENUM_ANY_OF` |
| `RULE_HIERARCHY` | `ATTRIBUTE_RULE_TYPE_ENUM_HIERARCHY` |
| `STATE_ACTIVE` | `ACTIVE_STATE_ENUM_ACTIVE` |
| `STATE_INACTIVE` | `ACTIVE_STATE_ENUM_INACTIVE` |
| `STATE_ANY` | `ACTIVE_STATE_ENUM_ANY` |

### Before / After

```java
// Before
ConditionGroup.newBuilder()
    .setBooleanOperator(ConditionBooleanTypeEnum.CONDITION_BOOLEAN_TYPE_ENUM_AND)
    .addConditions(Condition.newBuilder()
        .setOperator(SubjectMappingOperatorEnum.SUBJECT_MAPPING_OPERATOR_ENUM_IN));

// After
import static io.opentdf.platform.sdk.PolicyEnums.*;

ConditionGroup.newBuilder()
    .setBooleanOperator(BOOLEAN_AND)
    .addConditions(Condition.newBuilder()
        .setOperator(OPERATOR_IN));
```

## Test plan

- [x] `mvn compile` passes (full project including examples)
- [x] `mvn test -Dtest=PolicyEnumsTest` — 4 tests, all pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced simplified static constants for policy configuration, making attribute rules, operators, and boolean conditions more readable and intuitive to use.

* **Documentation**
  * Updated example code to demonstrate the new simplified policy constants.

* **Tests**
  * Added test coverage validating the new policy configuration constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->