### PR TITLE
fix(sdk): Lets ML-KEM PQ key encapsulation work

### DIFF
--- a/.github/workflows/update-platform-branch.yaml
+++ b/.github/workflows/update-platform-branch.yaml
@@ -5,6 +5,9 @@ name: "Update Platform Branch"
 #
 # To test:
 #   `act workflow_dispatch -W ./.github/workflows/update-platform-branch.yaml --input tag=protocol/go/v0.3.1`
+#
+# To run:
+#   `gh workflow run update-platform-branch.yaml --repo opentdf/java-sdk --ref main --field tag=protocol/go/v0.35.0`
 
 on:
   schedule:

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
@@ -101,9 +101,9 @@ public enum KeyType {
                 return KeyType.HybridSecp256r1MLKEM768Key;
             case ALGORITHM_HPQT_SECP384R1_MLKEM1024:
                 return KeyType.HybridSecp384r1MLKEM1024Key;
-            case ALGORITHM_ML_KEM_768:
+            case ALGORITHM_MLKEM_768:
                 return KeyType.MLKEM768Key;
-            case ALGORITHM_ML_KEM_1024:
+            case ALGORITHM_MLKEM_1024:
                 return KeyType.MLKEM1024Key;
             default:
                 throw new IllegalArgumentException("Unsupported algorithm: " + algorithm);

--- a/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/KeyType.java
@@ -101,6 +101,10 @@ public enum KeyType {
                 return KeyType.HybridSecp256r1MLKEM768Key;
             case ALGORITHM_HPQT_SECP384R1_MLKEM1024:
                 return KeyType.HybridSecp384r1MLKEM1024Key;
+            case ALGORITHM_ML_KEM_768:
+                return KeyType.MLKEM768Key;
+            case ALGORITHM_ML_KEM_1024:
+                return KeyType.MLKEM1024Key;
             default:
                 throw new IllegalArgumentException("Unsupported algorithm: " + algorithm);
         }
@@ -127,6 +131,10 @@ public enum KeyType {
                 return KeyType.HybridSecp256r1MLKEM768Key;
             case KAS_PUBLIC_KEY_ALG_ENUM_HPQT_SECP384R1_MLKEM1024:
                 return KeyType.HybridSecp384r1MLKEM1024Key;
+            case KAS_PUBLIC_KEY_ALG_ENUM_MLKEM_768:
+                return KeyType.MLKEM768Key;
+            case KAS_PUBLIC_KEY_ALG_ENUM_MLKEM_1024:
+                return KeyType.MLKEM1024Key;
             default:
                 throw new IllegalArgumentException(
                         "Unsupported KAS public-key algorithm: " + algorithm


### PR DESCRIPTION
Fixes missing cases to unwrap ML-KEM 768 and 1024 post-quantum key encapsulation for the Java SDK as part of the `mechanism-mlkem` feature.
