### PR TITLE
chore: fix duplicate plugin warning and disable snapshots

### DIFF
--- a/.github/release-please/release-please-config.main.json
+++ b/.github/release-please/release-please-config.main.json
@@ -5,6 +5,7 @@
   "separate-pull-requests": false,
   "include-component-in-tag": false,
   "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
+  "skip-snapshot": true,
   "packages": {
     ".": {}
   },

--- a/.github/release-please/release-please-config.release_branches.json
+++ b/.github/release-please/release-please-config.release_branches.json
@@ -5,6 +5,7 @@
   "separate-pull-requests": false,
   "include-component-in-tag": false,
   "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
+  "skip-snapshot": true,
   "packages": {
     ".": {}
   },

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -545,7 +545,7 @@
             </properties>
             <build>
                 <plugins>
-                    <!-- Plugin to download and unpack the Jazzer agent -->
+                    <!-- Plugin to download/unpack Jazzer agent and execute fuzzing -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
@@ -575,35 +575,6 @@
                                     <goal>run</goal>
                                 </goals>
                             </execution>
-                        </executions>
-                    </plugin>
-
-                    <!-- Copy dependencies to a directory for Jazzer to reference -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.4.0</version>
-                        <executions>
-                            <execution>
-                                <id>copy-dependencies</id>
-                                <phase>process-test-classes</phase>
-                                <goals>
-                                    <goal>copy-dependencies</goal>
-                                </goals>
-                                <configuration>
-                                    <outputDirectory>${project.build.directory}/dependency-jars</outputDirectory>
-                                    <includeScope>test</includeScope>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <!-- Plugin to execute Jazzer -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <executions>
                             <execution>
                                 <id>run-jazzer-fuzzing</id>
                                 <phase>verify</phase>
@@ -632,6 +603,26 @@
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Copy dependencies to a directory for Jazzer to reference -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>3.4.0</version>
+                        <executions>
+                            <execution>
+                                <id>copy-dependencies</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/dependency-jars</outputDirectory>
+                                    <includeScope>test</includeScope>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
* Don't use snapshots anymore since we don't publish them and we don't use them for 'integrate at HEAD' development
* Consolidate the duplicate definition of the antrun plugin to eliminate maven warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration settings across main and release branch configurations.
  * Reorganized Maven build profile configuration to improve build process consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->