### PR TITLE
fix: upgrade the publish plugin to avoid an error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.6.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <autoPublish>true</autoPublish>


### PR DESCRIPTION
sonatype has added new fields that the old plugin
doesn't understand. This causes an error during the
publish step. the actual publish to maven central succeeds
the action claims that it has failed.