### PR TITLE
feat(sdk): resolve attribute key splits via GetKeyMappingsByFqns during encrypt

### DIFF
--- a/sdk/src/main/java/io/opentdf/platform/sdk/Autoconfigure.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Autoconfigure.java
@@ -511,16 +511,26 @@ public class Autoconfigure {
                 }
                 for (var value : clause.values) {
                     var mapped = mappedKeys.get(value.key);
-                    if (mapped == null) {
-                        logger.warn("No keys found for attribute value {}", value);
+                    if (mapped != null && !mapped.isEmpty()) {
+                        for (var kasInfo : mapped) {
+                            if (kasInfo.URL == null || kasInfo.URL.isEmpty()) {
+                                logger.warn("No KAS URL found for attribute value {}", value);
+                                continue;
+                            }
+                            keys.add(new PublicKeyInfo(kasInfo.URL, kasInfo.KID, kasInfo.Algorithm));
+                        }
                         continue;
                     }
-                    for (var kasInfo : mapped) {
-                        if (kasInfo.URL == null || kasInfo.URL.isEmpty()) {
-                            logger.warn("No KAS URL found for attribute value {}", value);
-                            continue;
+                    // No mapped keys for this value; fall back to its URL-only legacy grants so
+                    // policies mixing mapped-key and legacy-grant values keep every KAS in the
+                    // plan. These grants carry only a KAS URL; the public key is resolved later.
+                    var grant = byAttribute(value);
+                    if (grant != null && !grant.kases.isEmpty()) {
+                        for (var kas : grant.kases) {
+                            keys.add(new PublicKeyInfo(kas));
                         }
-                        keys.add(new PublicKeyInfo(kasInfo.URL, kasInfo.KID, kasInfo.Algorithm));
+                    } else {
+                        logger.warn("No keys found for attribute value {}", value);
                     }
                 }
 
@@ -893,7 +903,7 @@ public class Autoconfigure {
             if (e.getCode() == Code.UNIMPLEMENTED) {
                 return newGranterFromAttributeValues(as, keyCache, Arrays.asList(fqns));
             }
-            throw new SDKException("error getting key mappings for attribute FQNs", e);
+            throw new AutoConfigureException("error getting key mappings for attribute FQNs", e);
         }
 
         Granter grants = new Granter(Arrays.asList(fqns));

--- a/sdk/src/main/java/io/opentdf/platform/sdk/Autoconfigure.java
+++ b/sdk/src/main/java/io/opentdf/platform/sdk/Autoconfigure.java
@@ -1,5 +1,7 @@
 package io.opentdf.platform.sdk;
 
+import com.connectrpc.Code;
+import com.connectrpc.ConnectException;
 import com.connectrpc.ResponseMessageKt;
 import io.opentdf.platform.policy.Algorithm;
 import io.opentdf.platform.policy.Attribute;
@@ -10,6 +12,8 @@ import io.opentdf.platform.policy.Value;
 import io.opentdf.platform.policy.attributes.AttributesServiceClientInterface;
 import io.opentdf.platform.policy.attributes.GetAttributeValuesByFqnsRequest;
 import io.opentdf.platform.policy.attributes.GetAttributeValuesByFqnsResponse;
+import io.opentdf.platform.policy.attributes.GetKeyMappingsByFqnsRequest;
+import io.opentdf.platform.policy.attributes.GetKeyMappingsByFqnsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -868,17 +872,72 @@ public class Autoconfigure {
         return getGranter(keyCache, attrsAndValues);
     }
 
-    // Gets a list of directory of KAS grants for a list of attribute FQNs
+    // Gets a directory of KAS grants for a list of attribute FQNs.
+    //
+    // Resolution uses GetKeyMappingsByFqns, which returns the effective mapped KAS
+    // keys per value (value > definition > namespace precedence, resolved
+    // server-side). Values that resolve to no mapped keys (e.g. configured only with
+    // legacy KAS grants) fall back to GetAttributeValuesByFqns so their grants still
+    // resolve. Older platforms that do not expose GetKeyMappingsByFqns fall back to
+    // the full attribute lookup for all values.
     static Granter newGranterFromService(AttributesServiceClientInterface as, KASKeyCache keyCache, AttributeValueFQN... fqns) throws AutoConfigureException {
-        GetAttributeValuesByFqnsRequest request = GetAttributeValuesByFqnsRequest.newBuilder()
-                .addAllFqns(Arrays.stream(fqns).map(AttributeValueFQN::toString).collect(Collectors.toList()))
-                .build();
+        GetKeyMappingsByFqnsResponse km;
+        try {
+            GetKeyMappingsByFqnsRequest request = GetKeyMappingsByFqnsRequest.newBuilder()
+                    .addAllFqns(Arrays.stream(fqns).map(AttributeValueFQN::toString).collect(Collectors.toList()))
+                    .build();
+            km = RequestHelper.getOrThrow(
+                    as.getKeyMappingsByFqnsBlocking(request, Collections.emptyMap()).execute()
+            );
+        } catch (ConnectException e) {
+            if (e.getCode() == Code.UNIMPLEMENTED) {
+                return newGranterFromAttributeValues(as, keyCache, Arrays.asList(fqns));
+            }
+            throw new SDKException("error getting key mappings for attribute FQNs", e);
+        }
 
-        GetAttributeValuesByFqnsResponse av = ResponseMessageKt.getOrThrow(
+        Granter grants = new Granter(Arrays.asList(fqns));
+        Map<String, GetKeyMappingsByFqnsResponse.AttributeKeyMapping> mappings = km.getFqnKeyMappingsMap();
+        List<AttributeValueFQN> fallback = new ArrayList<>();
+        for (AttributeValueFQN fqn : fqns) {
+            var mapping = mappings.get(fqn.getKey());
+            if (mapping == null || mapping.getKeysList().isEmpty()) {
+                // No mapped keys (legacy-grant-only, unconfigured, or omitted); resolve
+                // via the full attribute lookup below.
+                fallback.add(fqn);
+                continue;
+            }
+            // Only the FQN prefix and rule are read downstream (constructAttributeBoolean),
+            // so a minimal attribute is sufficient.
+            Attribute attr = Attribute.newBuilder()
+                    .setFqn(fqn.prefix().toString())
+                    .setRule(mapping.getRule())
+                    .build();
+            grants.addAllGrants(fqn, Collections.emptyList(), mapping.getKeysList(), attr);
+            storeKeysToCache(Collections.emptyList(), mapping.getKeysList(), keyCache);
+        }
+
+        if (!fallback.isEmpty()) {
+            GetAttributeValuesByFqnsResponse av = fetchAttributeValues(as, fallback);
+            addGrantsFromAttributeValues(grants, keyCache, new ArrayList<>(av.getFqnAttributeValuesMap().values()));
+        }
+
+        return grants;
+    }
+
+    // Resolves grants for the given FQNs via the full GetAttributeValuesByFqns lookup.
+    private static Granter newGranterFromAttributeValues(AttributesServiceClientInterface as, KASKeyCache keyCache, List<AttributeValueFQN> fqns) throws AutoConfigureException {
+        GetAttributeValuesByFqnsResponse av = fetchAttributeValues(as, fqns);
+        return getGranter(keyCache, new ArrayList<>(av.getFqnAttributeValuesMap().values()));
+    }
+
+    private static GetAttributeValuesByFqnsResponse fetchAttributeValues(AttributesServiceClientInterface as, List<AttributeValueFQN> fqns) throws AutoConfigureException {
+        GetAttributeValuesByFqnsRequest request = GetAttributeValuesByFqnsRequest.newBuilder()
+                .addAllFqns(fqns.stream().map(AttributeValueFQN::toString).collect(Collectors.toList()))
+                .build();
+        return ResponseMessageKt.getOrThrow(
                 as.getAttributeValuesByFqnsBlocking(request, Collections.emptyMap()).execute()
         );
-
-        return getGranter(keyCache, new ArrayList<>(av.getFqnAttributeValuesMap().values()));
     }
 
 
@@ -901,6 +960,14 @@ public class Autoconfigure {
                 .collect(Collectors.toList());
 
         Granter grants = new Granter(attributeValues);
+        addGrantsFromAttributeValues(grants, keyCache, values);
+        return grants;
+    }
+
+    // Populates an existing Granter from GetAttributeValuesByFqns results, resolving
+    // grants with value > definition > namespace precedence.
+    private static void addGrantsFromAttributeValues(Granter grants, @Nullable KASKeyCache keyCache,
+            List<GetAttributeValuesByFqnsResponse.AttributeAndValue> values) {
         for (var attributeAndValue: values) {
             String fqnstr = attributeAndValue.getValue().getFqn();
             AttributeValueFQN fqn = new AttributeValueFQN(fqnstr);
@@ -921,8 +988,6 @@ public class Autoconfigure {
                 storeKeysToCache(namespace.getGrantsList(), namespace.getKasKeysList(), keyCache);
             }
         }
-
-        return grants;
     }
 
     static void storeKeysToCache(List<KeyAccessServer> kases, List<SimpleKasKey> kasKeys, KASKeyCache keyCache) {

--- a/sdk/src/test/java/io/opentdf/platform/sdk/AutoconfigureTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/AutoconfigureTest.java
@@ -1,5 +1,7 @@
 package io.opentdf.platform.sdk;
 
+import com.connectrpc.Code;
+import com.connectrpc.ConnectException;
 import com.connectrpc.ResponseMessage;
 import com.connectrpc.UnaryBlockingCall;
 import io.opentdf.platform.policy.Algorithm;
@@ -17,6 +19,8 @@ import io.opentdf.platform.policy.Value;
 import io.opentdf.platform.policy.attributes.AttributesServiceClient;
 import io.opentdf.platform.policy.attributes.GetAttributeValuesByFqnsRequest;
 import io.opentdf.platform.policy.attributes.GetAttributeValuesByFqnsResponse;
+import io.opentdf.platform.policy.attributes.GetKeyMappingsByFqnsRequest;
+import io.opentdf.platform.policy.attributes.GetKeyMappingsByFqnsResponse;
 import io.opentdf.platform.sdk.Autoconfigure.AttributeValueFQN;
 import io.opentdf.platform.sdk.Autoconfigure.Granter;
 import io.opentdf.platform.sdk.Autoconfigure.Granter.AttributeBooleanExpression;
@@ -551,6 +555,59 @@ public class AutoconfigureTest {
         ));
     }
 
+    @Test
+    void testNewGranterFromServiceUsesKeyMappings() {
+        var attributeService = mock(AttributesServiceClient.class);
+        when(attributeService.getKeyMappingsByFqnsBlocking(any(), any())).thenAnswer(invocation -> {
+            var req = (GetKeyMappingsByFqnsRequest) invocation.getArgument(0);
+            var builder = GetKeyMappingsByFqnsResponse.newBuilder();
+            for (String fqn : req.getFqnsList()) {
+                builder.putFqnKeyMappings(fqn.toLowerCase(),
+                        GetKeyMappingsByFqnsResponse.AttributeKeyMapping.newBuilder()
+                                .setRule(AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF)
+                                .addKeys(VALUE_KEY)
+                                .build());
+            }
+            return TestUtil.successfulUnaryCall(builder.build());
+        });
+
+        var fqn = new AttributeValueFQN("https://mapped.example.com/attr/attr1/value/value1");
+        Granter granter = Autoconfigure.newGranterFromService(attributeService, new KASKeyCache(), fqn);
+        assertThat(granter).isNotNull();
+
+        var counter = new AtomicInteger(0);
+        var splitPlan = granter.getSplits(Collections.emptyList(), () -> Integer.toString(counter.getAndIncrement()), Optional::empty);
+        assertThat(splitPlan).isEqualTo(List.of(
+                new Autoconfigure.KeySplitTemplate(VALUE_KEY.getKasUri(), "", VALUE_KEY.getPublicKey().getKid(), KeyType.EC521Key)));
+        // The mapped-key path must not fall back to the deprecated full lookup.
+        verify(attributeService, never()).getAttributeValuesByFqnsBlocking(any(), any());
+    }
+
+    @Test
+    void testNewGranterFromServiceFallsBackWhenKeyMappingsEmpty() {
+        var attributeService = mock(AttributesServiceClient.class);
+        // Mapping present but with no mapped keys (legacy-grant-only value).
+        when(attributeService.getKeyMappingsByFqnsBlocking(any(), any())).thenAnswer(invocation -> {
+            var req = (GetKeyMappingsByFqnsRequest) invocation.getArgument(0);
+            var builder = GetKeyMappingsByFqnsResponse.newBuilder();
+            for (String fqn : req.getFqnsList()) {
+                builder.putFqnKeyMappings(fqn.toLowerCase(),
+                        GetKeyMappingsByFqnsResponse.AttributeKeyMapping.newBuilder().build());
+            }
+            return TestUtil.successfulUnaryCall(builder.build());
+        });
+        when(attributeService.getAttributeValuesByFqnsBlocking(any(), any())).thenAnswer(invocation -> {
+            var req = (GetAttributeValuesByFqnsRequest) invocation.getArgument(0);
+            return TestUtil.successfulUnaryCall(getResponse(req));
+        });
+
+        Granter granter = Autoconfigure.newGranterFromService(attributeService, new KASKeyCache(),
+                clsS, rel2gbr, rel2usa, n2kHCS, n2kSI);
+        assertThat(granter).isNotNull();
+        // The empty-key FQNs must be resolved through the full attribute lookup.
+        verify(attributeService).getAttributeValuesByFqnsBlocking(any(), any());
+    }
+
     GetAttributeValuesByFqnsResponse getResponse(GetAttributeValuesByFqnsRequest req) {
         GetAttributeValuesByFqnsResponse.Builder builder = GetAttributeValuesByFqnsResponse.newBuilder();
 
@@ -669,6 +726,10 @@ public class AutoconfigureTest {
                     }
                 };
             });
+            // These cases resolve via legacy grants; simulate a platform without
+            // GetKeyMappingsByFqns so resolution falls back to GetAttributeValuesByFqns.
+            when(attributeService.getKeyMappingsByFqnsBlocking(any(), any()))
+                    .thenReturn(TestUtil.failedUnaryCall(Code.UNIMPLEMENTED, "unimplemented"));
 
 
             Granter reasoner = Autoconfigure.newGranterFromService(attributeService, new KASKeyCache(),
@@ -985,6 +1046,10 @@ public class AutoconfigureTest {
                 }
             };
         });
+        // Legacy-grant resolution: simulate a platform without GetKeyMappingsByFqns so
+        // resolution falls back to GetAttributeValuesByFqns.
+        when(attributesServiceClient.getKeyMappingsByFqnsBlocking(any(), any()))
+                .thenReturn(TestUtil.failedUnaryCall(Code.UNIMPLEMENTED, "unimplemented"));
 
         KASKeyCache keyCache = new KASKeyCache();
 
@@ -1103,6 +1168,8 @@ public class AutoconfigureTest {
             }
             return TestUtil.successfulUnaryCall(builder.build());
         });
+        when(attributesServiceClient.getKeyMappingsByFqnsBlocking(any(), any()))
+                .thenReturn(TestUtil.failedUnaryCall(Code.UNIMPLEMENTED, "unimplemented"));
 
         // Act
         Autoconfigure.Granter granter = Autoconfigure.createGranter(services, new Config.TDFConfig() {{

--- a/sdk/src/test/java/io/opentdf/platform/sdk/AutoconfigureTest.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/AutoconfigureTest.java
@@ -1,7 +1,6 @@
 package io.opentdf.platform.sdk;
 
 import com.connectrpc.Code;
-import com.connectrpc.ConnectException;
 import com.connectrpc.ResponseMessage;
 import com.connectrpc.UnaryBlockingCall;
 import io.opentdf.platform.policy.Algorithm;
@@ -606,6 +605,86 @@ public class AutoconfigureTest {
         assertThat(granter).isNotNull();
         // The empty-key FQNs must be resolved through the full attribute lookup.
         verify(attributeService).getAttributeValuesByFqnsBlocking(any(), any());
+    }
+
+    // A policy mixing a mapped-key value with a legacy-grant-only value must keep both
+    // KASes in the split plan; the mapped value sets hasMappedKeys, and the legacy
+    // value's URL-only grant must not be dropped by the mapped-key plan path.
+    @Test
+    void testNewGranterFromServiceMixedMappedAndLegacyGrants() {
+        final String kasMapped = "https://kas-mapped.example/kas";
+        final String kasLegacy = "https://kas-legacy.example/kas";
+        var fqnMapped = new AttributeValueFQN("https://mapped.example.com/attr/attrA/value/one");
+        var fqnLegacy = new AttributeValueFQN("https://mapped.example.com/attr/attrB/value/two");
+
+        var mappedKey = SimpleKasKey.newBuilder()
+                .setKasUri(kasMapped)
+                .setKasId("kas-mapped")
+                .setPublicKey(SimpleKasPublicKey.newBuilder()
+                        .setAlgorithm(Algorithm.ALGORITHM_EC_P256)
+                        .setKid("mapped-kid")
+                        .setPem("mapped-pem")
+                        .build())
+                .build();
+
+        var attributeService = mock(AttributesServiceClient.class);
+        // Key mappings resolve the first value; the second returns no mapped keys.
+        when(attributeService.getKeyMappingsByFqnsBlocking(any(), any())).thenAnswer(invocation -> {
+            var req = (GetKeyMappingsByFqnsRequest) invocation.getArgument(0);
+            var builder = GetKeyMappingsByFqnsResponse.newBuilder();
+            for (String fqn : req.getFqnsList()) {
+                var mapping = GetKeyMappingsByFqnsResponse.AttributeKeyMapping.newBuilder()
+                        .setRule(AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF);
+                if (fqn.equalsIgnoreCase(fqnMapped.toString())) {
+                    mapping.addKeys(mappedKey);
+                }
+                builder.putFqnKeyMappings(fqn.toLowerCase(), mapping.build());
+            }
+            return TestUtil.successfulUnaryCall(builder.build());
+        });
+        // The legacy value falls back to the full lookup and carries only a URL grant.
+        when(attributeService.getAttributeValuesByFqnsBlocking(any(), any())).thenAnswer(invocation -> {
+            var legacyValue = Value.newBuilder()
+                    .setFqn(fqnLegacy.toString())
+                    .addGrants(KeyAccessServer.newBuilder().setUri(kasLegacy).build())
+                    .setAttribute(Attribute.newBuilder()
+                            .setFqn(fqnLegacy.prefix().toString())
+                            .setRule(AttributeRuleTypeEnum.ATTRIBUTE_RULE_TYPE_ENUM_ALL_OF)
+                            .setNamespace(Namespace.newBuilder().setFqn("https://mapped.example.com").build())
+                            .build())
+                    .build();
+            var resp = GetAttributeValuesByFqnsResponse.newBuilder()
+                    .putFqnAttributeValues(fqnLegacy.toString(),
+                            GetAttributeValuesByFqnsResponse.AttributeAndValue.newBuilder()
+                                    .setValue(legacyValue)
+                                    .setAttribute(legacyValue.getAttribute())
+                                    .build())
+                    .build();
+            return TestUtil.successfulUnaryCall(resp);
+        });
+
+        Granter granter = Autoconfigure.newGranterFromService(attributeService, new KASKeyCache(), fqnMapped, fqnLegacy);
+        var counter = new AtomicInteger(0);
+        var splits = granter.getSplits(Collections.emptyList(),
+                () -> Integer.toString(counter.getAndIncrement()), Optional::empty);
+
+        var kasUris = splits.stream().map(s -> s.kas).collect(Collectors.toList());
+        assertThat(kasUris).contains(kasMapped, kasLegacy);
+    }
+
+    // A non-Unimplemented failure from GetKeyMappingsByFqns surfaces as an
+    // AutoConfigureException (this method's declared exception) and must not trigger
+    // the legacy GetAttributeValuesByFqns fallback.
+    @Test
+    void testNewGranterFromServiceWrapsNonUnimplementedError() {
+        var attributeService = mock(AttributesServiceClient.class);
+        when(attributeService.getKeyMappingsByFqnsBlocking(any(), any()))
+                .thenReturn(TestUtil.failedUnaryCall(Code.UNAVAILABLE, "server unavailable"));
+
+        assertThatThrownBy(() -> Autoconfigure.newGranterFromService(attributeService, new KASKeyCache(),
+                new AttributeValueFQN("https://example.com/attr/a/value/b")))
+                .isInstanceOf(AutoConfigureException.class);
+        verify(attributeService, never()).getAttributeValuesByFqnsBlocking(any(), any());
     }
 
     GetAttributeValuesByFqnsResponse getResponse(GetAttributeValuesByFqnsRequest req) {

--- a/sdk/src/test/java/io/opentdf/platform/sdk/TestUtil.java
+++ b/sdk/src/test/java/io/opentdf/platform/sdk/TestUtil.java
@@ -1,5 +1,7 @@
 package io.opentdf.platform.sdk;
 
+import com.connectrpc.Code;
+import com.connectrpc.ConnectException;
 import com.connectrpc.ResponseMessage;
 import com.connectrpc.UnaryBlockingCall;
 
@@ -28,6 +30,24 @@ public class TestUtil {
             @Override
             public void cancel() {
                 // in tests we don't need to preserve server resources, so no-op
+            }
+        };
+    }
+
+    // A unary call that fails with the given code, e.g. to simulate a platform that
+    // does not implement a newer RPC.
+    static <T> UnaryBlockingCall<T> failedUnaryCall(Code code, String message) {
+        return new UnaryBlockingCall<T>() {
+            @Override
+            public ResponseMessage<T> execute() {
+                return new ResponseMessage.Failure<>(
+                        new ConnectException(code, message, null, Collections.emptyMap()),
+                        Collections.emptyMap(), Collections.emptyMap());
+            }
+
+            @Override
+            public void cancel() {
+                // no-op in tests
             }
         };
     }


### PR DESCRIPTION
## What / Why

The policy RPC `GetAttributeValuesByFqns` is deprecated in favor of narrower read APIs. For the client-side encrypt (autoconfigure / key-split) path the replacement is `GetKeyMappingsByFqns`, which returns the server-resolved effective KAS keys and attribute rule per value FQN (value > definition > namespace). This migrates the Java SDK encrypt path onto it, matching the platform Go SDK which already resolves splits this way.

## Changes

- `Autoconfigure.newGranterFromService` now calls `getKeyMappingsByFqnsBlocking` first. For each requested FQN with mapped keys, a minimal `Attribute` (FQN prefix + rule, the only fields read by `constructAttributeBoolean`) feeds the existing `addAllGrants` / `getSplits` pipeline, so `hasMappedKeys -> planFromAttributes` is unchanged.
- FQNs with no mapped keys (e.g. legacy KAS grants) are collected and resolved through a single `getAttributeValuesByFqns` fallback; platforms returning `Unimplemented` fall back for all FQNs.
- The attribute-values population loop is factored out of `getGranter` into `addGrantsFromAttributeValues` so both the offline path and the fallback reuse it.

No proto-version bump is required: `platform.branch` (`protocol/go/v0.39.0`) already defines `GetKeyMappingsByFqns`, so the generated stub appears on regeneration.

## Fallback Order

Mapped keys from `GetKeyMappingsByFqns`, then legacy grants via `GetAttributeValuesByFqns` for empty-key FQNs, then the existing base-key / default-KAS behavior. An empty key set never bypasses the grant fallback.

## How to Test

`mvn -pl sdk test -Dtest=AutoconfigureTest`, and the full `sdk` module suite. Verified locally (JDK 17): `AutoconfigureTest` 21/21, full `sdk` module 212/212.

- Existing cases exercise the `Unimplemented` fallback via a failed-call stub (`TestUtil.failedUnaryCall`).
- New cases: mapped-key path (asserts `getAttributeValuesByFqns` is never called) and empty-mapping legacy fallback.

## Risk

Touches the encrypt key-split path. No change to produced TDFs for existing policy configurations: mapped-key values resolve to the same KAS keys server-side, and legacy-grant values take the unchanged `GetAttributeValuesByFqns` path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved grant creation by using effective KAS key mappings when available.
  * Added fallback resolution for unmapped attributes and services that do not support key mappings.
  * Preserved attribute value, definition, and namespace precedence during grant processing.
  * Supported policies that combine mapped keys with legacy grant entries.

* **Bug Fixes**
  * Improved compatibility with legacy grant-resolution services and responses.
  * Added clearer handling for key-mapping service connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->